### PR TITLE
Add blocky identicons to chat message UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,11 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@download/blockies": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@download/blockies/-/blockies-1.0.3.tgz",
+      "integrity": "sha512-iGDh2M6pFuXg9kyW+U//963LKylSLFpLG5hZvUppCjhkiDwsYquQPyamxCQlLASYySS3gGKAki2eWG9qIHKCew=="
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
@@ -6973,9 +6978,10 @@
     "packages/frontend": {
       "name": "universal-connectivity-browser",
       "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "github:maschad/js-libp2p-gossipsub#fix/add-mesh-peers-to-sub",
+        "@chainsafe/libp2p-gossipsub": "6.2.0",
         "@chainsafe/libp2p-noise": "^11.0.0",
         "@chainsafe/libp2p-yamux": "^3.0.5",
+        "@download/blockies": "^1.0.3",
         "@headlessui/react": "^1.7.13",
         "@heroicons/react": "^2.0.16",
         "@libp2p/bootstrap": "^6.0.0",
@@ -7376,6 +7382,11 @@
         "it-pushable": "^3.1.0",
         "uint8arraylist": "^2.3.2"
       }
+    },
+    "@download/blockies": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@download/blockies/-/blockies-1.0.3.tgz",
+      "integrity": "sha512-iGDh2M6pFuXg9kyW+U//963LKylSLFpLG5hZvUppCjhkiDwsYquQPyamxCQlLASYySS3gGKAki2eWG9qIHKCew=="
     },
     "@eslint/eslintrc": {
       "version": "2.0.0",
@@ -12021,9 +12032,10 @@
     "universal-connectivity-browser": {
       "version": "file:packages/frontend",
       "requires": {
-        "@chainsafe/libp2p-gossipsub": "github:maschad/js-libp2p-gossipsub#fix/add-mesh-peers-to-sub",
+        "@chainsafe/libp2p-gossipsub": "6.2.0",
         "@chainsafe/libp2p-noise": "^11.0.0",
         "@chainsafe/libp2p-yamux": "^3.0.5",
+        "@download/blockies": "^1.0.3",
         "@headlessui/react": "^1.7.13",
         "@heroicons/react": "^2.0.16",
         "@libp2p/bootstrap": "^6.0.0",
@@ -12057,7 +12069,7 @@
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": {
           "version": "git+ssh://git@github.com/maschad/js-libp2p-gossipsub.git#7dfe78394e6ede17ae87d1d7d7f3f2005b16ce1d",
-          "from": "@chainsafe/libp2p-gossipsub@github:maschad/js-libp2p-gossipsub#fix/add-mesh-peers-to-sub",
+          "from": "@chainsafe/libp2p-gossipsub@6.2.0",
           "requires": {
             "@libp2p/crypto": "^1.0.3",
             "@libp2p/interface-connection": "^3.0.1",

--- a/packages/frontend/blockies.d.ts
+++ b/packages/frontend/blockies.d.ts
@@ -1,0 +1,1 @@
+declare module '@download/blockies'

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "@chainsafe/libp2p-gossipsub": "6.2.0",
     "@chainsafe/libp2p-noise": "^11.0.0",
     "@chainsafe/libp2p-yamux": "^3.0.5",
+    "@download/blockies": "^1.0.3",
     "@headlessui/react": "^1.7.13",
     "@heroicons/react": "^2.0.16",
     "@libp2p/bootstrap": "^6.0.0",

--- a/packages/frontend/src/components/chat.tsx
+++ b/packages/frontend/src/components/chat.tsx
@@ -14,7 +14,7 @@ interface ChatMessage {
 interface MessageProps extends ChatMessage {}
 
 function Message({ msg, from, peerId }: MessageProps) {
-  const msgref = React.useRef<HTMLDivElement>(null)
+  const msgref = React.useRef<HTMLLIElement>(null)
 
   useEffect(() => {
     const icon = createIcon({
@@ -22,7 +22,7 @@ function Message({ msg, from, peerId }: MessageProps) {
       size: 15,
       scale: 3,
     })
-    icon.className = 'rounded mr-2'
+    icon.className = 'rounded mr-2 max-h-10 max-w-10'
     const childrenCount = msgref.current?.childElementCount
     // Prevent inserting an icon more than once.
     if (childrenCount && childrenCount < 2) {
@@ -31,9 +31,9 @@ function Message({ msg, from, peerId }: MessageProps) {
   }, [peerId])
 
   return (
-    <li className={`flex ${from === 'me' ? 'justify-end' : 'justify-start'}`}>
+    <li ref={msgref} className={`flex ${from === 'me' ? 'justify-end' : 'justify-start'}`}>
       <div
-        ref={msgref}
+
         className="flex relative max-w-xl px-4 py-2 text-gray-700 rounded shadow"
       >
         <span className="block">{msg}</span>


### PR DESCRIPTION
- Refactor the chat message into a separate component to allow integration of blockies in the `useEffect` hook.
- Get peer ID string of every sender and use it as a seed to each blocky.
- FIXME: TypeScript yells that 'from' doesn't exist in type 'Message', which apparently is a variant type of either 'SignedMessage' or 'UnsignedMessage', of which the first contains 'from' attribute. Currently the 'Message' is being casted as 'any' as a quick fix for this.