### PR TITLE
fix: render signed messages

### DIFF
--- a/packages/frontend/src/components/chat.tsx
+++ b/packages/frontend/src/components/chat.tsx
@@ -57,9 +57,9 @@ export default function ChatContainer() {
       console.log(`${topic}: ${msg}`)
 
       if (evt.detail.type === 'signed') {
-        const peerId = evt.detail.from.toString()
+        setMessages([...messages, { msg, from: 'other', peerId: evt.detail.from.toString() }])
       } else {
-        setMessages([...messages, { msg, from: 'other', peerId: 'unkonwn' }])
+        const peerId = evt.detail.toString()
       }
       // Append new message
     }

--- a/packages/frontend/src/components/chat.tsx
+++ b/packages/frontend/src/components/chat.tsx
@@ -56,12 +56,10 @@ export default function ChatContainer() {
       const msg = new TextDecoder().decode(data)
       console.log(`${topic}: ${msg}`)
 
+      // Append signed messages, otherwise discard
       if (evt.detail.type === 'signed') {
         setMessages([...messages, { msg, from: 'other', peerId: evt.detail.from.toString() }])
-      } else {
-        const peerId = evt.detail.toString()
       }
-      // Append new message
     }
 
     libp2p.pubsub.addEventListener('message', messageCB)


### PR DESCRIPTION
Fixes incorrect logic where signed messages were discarded

<img width="406" alt="image" src="https://user-images.githubusercontent.com/50885601/230492569-92c2fee2-feb2-4d8a-851d-508a5841d676.png">

closes https://github.com/libp2p/universal-connectivity/issues/10
