### PR TITLE
feat(go/kademlia): Use custom protocol

### DIFF
--- a/go-peer/main.go
+++ b/go-peer/main.go
@@ -44,6 +44,8 @@ func NewDHT(ctx context.Context, host host.Host, bootstrapPeers []multiaddr.Mult
 		options = append(options, dht.Mode(dht.ModeServer))
 	}
 
+	options = append(options, dht.ProtocolPrefix("/universal-connectivity"))
+
 	kdht, err := dht.New(ctx, host, options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Counterpart to https://github.com/libp2p/universal-connectivity/pull/27

```
➜  libp2p-lookup direct --address /ip4/127.0.0.1/udp/53681/quic-v1
Lookup for peer with id PeerId("12D3KooWAzjjDrqz4GwKzEG3DChnS7pQq1YdRfDELqG46AeiRw6m") succeeded.

Protocol version: "ipfs/0.1.0"
Agent version: "github.com/libp2p/universal-connectivity/go-peer@"
Observed address: "/ip4/127.0.0.1/udp/39383/quic-v1"
Listen addresses:
        - "/ip4/192.168.2.109/udp/53681/quic-v1"
        - "/ip4/127.0.0.1/udp/53681/quic-v1"
        - "/ip6/2003:ea:e728:da92:b841:7b35:e403:ad83/udp/54457/quic-v1"
        - "/ip6/::1/udp/54457/quic-v1"
        - "/ip4/84.132.144.14/udp/53681/quic-v1"
Protocols:
        - "/ipfs/ping/1.0.0"
        - "/libp2p/circuit/relay/0.2.0/stop"
        - "/ipfs/id/1.0.0"
        - "/ipfs/id/push/1.0.0"
        - "/meshsub/1.1.0"
        - "/meshsub/1.0.0"
        - "/floodsub/1.0.0"
        - "/universal-connectivity/kad/1.0.0"
```

See final line.