### PR TITLE
fix: increase maxPushOutgoingStreams limit to resolve err

### DIFF
--- a/packages/frontend/src/lib/libp2p.ts
+++ b/packages/frontend/src/lib/libp2p.ts
@@ -94,6 +94,9 @@ export async function startLibp2p(options: {} = {}) {
       msgIdFn: msgIdFnStrictNoSign,
       ignoreDuplicatePublishError: true,
     }),
+    identify: {
+      maxPushOutgoingStreams: 2,
+    },
     // connectionManager: {
     //   minConnections: 0,
     //   maxConnections: 3,


### PR DESCRIPTION
Resolves this error:
```
common.js:113 libp2p:upgrader:error could not create new stream +0ms CodeError: Too many outbound protocol streams for protocol "/ipfs/id/push/1.0.0" - limit 1
    at ConnectionImpl.newStream [as _newStream] (upgrader.js:325:1)
    at async ConnectionImpl.newStream (index.js:55:1)
    at async eval (index.js:99:1)
    at async Promise.all (:3000/index 0)
    at async IdentifyService.push (index.js:121:1)
    at async IdentifyService.pushToPeerStore (index.js:140:1)

19:55:26.435 common.js:113 libp2p:identify:error could not push identify update to peer +0ms CodeError: Too many outbound protocol streams for protocol "/ipfs/id/push/1.0.0" - limit 1
    at ConnectionImpl.newStream [as _newStream] (upgrader.js:325:1)
    at async ConnectionImpl.newStream (index.js:55:1)
    at async eval (index.js:99:1)
    at async Promise.all (:3000/index 0)
    at async IdentifyService.push (index.js:121:1)
    at async IdentifyService.pushToPeerStore (index.js:140:1)
```