### PR TITLE
fix: identify timeout

### DIFF
--- a/rust-peer/src/main.rs
+++ b/rust-peer/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<()> {
                     info!("{peer_id} subscribed to {topic}");
                 }
                 SwarmEvent::Behaviour(BehaviourEvent::Identify(e)) => {
-                    debug!("{:?}", e);
+                    info!("BehaviourEvent::Identify {:?}", e);
 
                     if let identify::Event::Received {
                         peer_id,
@@ -216,7 +216,6 @@ fn create_swarm() -> Result<Swarm<Behaviour>> {
 
     let identify_config = identify::Behaviour::new(
         identify::Config::new("/ipfs/0.1.0".into(), local_key.public().clone())
-            .with_initial_delay(Duration::ZERO),
     );
 
     // Create a Kademlia behaviour.


### PR DESCRIPTION
The `.with_initial_delay(Duration::ZERO)` was causing a timeout in identify
```
[2023-04-11T03:49:49Z INFO  rust_libp2p_webrtc_peer] BehaviourEvent::Identify Error { peer_id: PeerId("12D3KooWHv4mwDZuC9mEHUmiY54ccJSTK5vfEcSwwR3VSUEcCg16"), error: Timeout }
```

removing it actually allows us to get a `BehaviourEvent::Identify Received`