### PR TITLE
fix: delay autonat start by 1 day

### DIFF
--- a/packages/frontend/src/lib/libp2p.ts
+++ b/packages/frontend/src/lib/libp2p.ts
@@ -71,6 +71,9 @@ export async function startLibp2p(options: {} = {}) {
     identify: {
       maxPushOutgoingStreams: 2,
     },
+    autonat: {
+      startupDelay: 60 * 60 *24 * 1000,
+    },
   })
 
   libp2p.pubsub.subscribe(CHAT_TOPIC)


### PR DESCRIPTION
Since AutoNat cannot be explicitly disabled, delay its start by 1 day