### PR TITLE
Add dependabot file

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/rust-peer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 9999
+    commit-message:
+      prefix: "deps"
+    rebase-strategy: "disabled"
+    groups:
+      libp2p:
+        patterns:
+          - "libp2p"
+          - "libp2p-*"


### PR DESCRIPTION
This only adds the Rust configuration for now. Other teams (@libp2p/go-libp2p-maintainers & @libp2p/js-libp2p-chainsafe-maintainers) are welcome to add their desired configuration after!