### PR TITLE
bump golang + go-libp2p deps

### DIFF
--- a/go-peer/go.mod
+++ b/go-peer/go.mod
@@ -1,10 +1,10 @@
 module github.com/libp2p/universal-connectivity/go-peer
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gdamore/tcell/v2 v2.6.0
-	github.com/libp2p/go-libp2p v0.27.1
+	github.com/libp2p/go-libp2p v0.31.0
 	github.com/libp2p/go-libp2p-kad-dht v0.23.0
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/multiformats/go-multiaddr v0.9.0


### PR DESCRIPTION
bumping:

golang to 1.21
go-libp2p to v0.31.0

and life is good. I'll submit another PR later that attempts to enable WASI builds here but it's failing hard ->

after fixing imports: 
```
replace go.uber.org/fx v1.20.0 => github.com/maceip/fx v0.0.0-20230925211015-d2b444db7f67

replace github.com/libp2p/go-netroute v0.2.1 => github.com/maceip/go-netroute v0.2.2-0.20230925214737-ac11d2898240
```
and ripping out the UI code, you can compile it with:

```
GOOS=wasip1 GOARCH=wasm go build .
```

and host it via:

```
wasirun --dir . --env-inherit --trace --listen 0.0.0.0:9095 go-peer
```
but it barfs with net/fs issues .... /me sulks away