### PR TITLE
Test peer discovery with public DHT

### DIFF
--- a/js-peer/src/lib/libp2p.ts
+++ b/js-peer/src/lib/libp2p.ts
@@ -60,8 +60,10 @@ export async function startLibp2p() {
     peerDiscovery: [
       bootstrap({
         list: [
-          WEBRTC_BOOTSTRAP_NODE,
-          WEBTRANSPORT_BOOTSTRAP_NODE,
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
         ],
       }),
     ],

--- a/js-peer/src/lib/libp2p.ts
+++ b/js-peer/src/lib/libp2p.ts
@@ -74,7 +74,7 @@ export async function startLibp2p() {
         ignoreDuplicatePublishError: true,
       }),
       dht: kadDHT({
-        protocolPrefix: "/universal-connectivity",
+        // protocolPrefix: "/universal-connectivity",
         maxInboundStreams: 5000,
         maxOutboundStreams: 5000,
         clientMode: true,


### PR DESCRIPTION
- js-peer: connect to public libp2p bootstrap nodes
- remove dht protocol prefix to use public dht
