### PR TITLE
ci: set up CI for Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,11 @@ jobs:
       - run: cargo fmt -- --check
       - run: cargo clippy
       - run: cargo test
+  go-check:
+    uses: pl-strflt/uci/.github/workflows/go-check@v0.0
+    with:
+      go-version: '1.21'
+  go-test:
+    uses: pl-strflt/uci/.github/workflows/go-test@v0.0
+    with:
+      go-versions: '["1.21"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       - run: cargo clippy
       - run: cargo test
   go-check:
-    uses: pl-strflt/uci/.github/workflows/go-check@v0.0
+    uses: pl-strflt/uci/.github/workflows/go-check.yml@v0.0
     with:
-      go-version: '1.21'
+      go-version: '1.21.x'
   go-test:
-    uses: pl-strflt/uci/.github/workflows/go-test@v0.0
+    uses: pl-strflt/uci/.github/workflows/go-test.yml@v0.0
     with:
-      go-versions: '["1.21"]'
+      go-versions: '["1.21.x"]'

--- a/go-peer/flag.go
+++ b/go-peer/flag.go
@@ -7,10 +7,10 @@ import "strings"
 type stringSlice []string
 
 func (s *stringSlice) String() string {
-    return strings.Join(*s, ", ")
+	return strings.Join(*s, ", ")
 }
 
 func (s *stringSlice) Set(value string) error {
-    *s = append(*s, value)
-    return nil
+	*s = append(*s, value)
+	return nil
 }

--- a/go-peer/identity.go
+++ b/go-peer/identity.go
@@ -1,4 +1,5 @@
 package main
+
 // Borrowed from https://github.com/libp2p/go-libp2p-relay-daemon/blob/master/identity.go
 
 import (

--- a/go-peer/main.go
+++ b/go-peer/main.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -136,13 +136,13 @@ func main() {
 		f, err := os.OpenFile("log.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			log.Println("failed to open log file", err)
-			log.SetOutput(ioutil.Discard)
+			log.SetOutput(io.Discard)
 		} else {
 			defer f.Close()
 			log.SetOutput(f)
 		}
 	} else {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Resolves https://github.com/libp2p/universal-connectivity/issues/99

This PR adds Go support to the CI. It does so by reusing reusable workflows from Unified CI. We're not enlisting `universal-connectivity` for full CI because the setup here is non-common. One reason why we might have wanted to opt-in for uCI is automatic Go upgrades but it looks like we're already ahead of everything else here.