### PR TITLE
feat: use ipfs dht

### DIFF
--- a/go-peer/main.go
+++ b/go-peer/main.go
@@ -38,17 +38,11 @@ var SysMsgChan chan *ChatMessage
 // NewDHT attempts to connect to a bunch of bootstrap peers and returns a new DHT.
 // If you don't have any bootstrapPeers, you can use dht.DefaultBootstrapPeers or an empty list.
 func NewDHT(ctx context.Context, host host.Host, bootstrapPeers []multiaddr.Multiaddr) (*dht.IpfsDHT, error) {
-	var options []dht.Option
 
-	// if no bootstrap peers give this peer act as a bootstraping node
-	// other peers can use this peers ipfs address for peer discovery via dht
-	if len(bootstrapPeers) == 0 {
-		options = append(options, dht.Mode(dht.ModeServer))
-	}
-
-	options = append(options, dht.ProtocolPrefix("/universal-connectivity/lan"))
-
-	kdht, err := dht.New(ctx, host, options...)
+	kdht, err := dht.New(ctx, host,
+		dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
+		dht.Mode(dht.ModeAuto),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/js-peer/src/lib/libp2p.ts
+++ b/js-peer/src/lib/libp2p.ts
@@ -73,9 +73,6 @@ export async function startLibp2p() {
         ignoreDuplicatePublishError: true,
       }),
       dht: kadDHT({
-        protocol: "/universal-connectivity/kad/1.0.0",
-        maxInboundStreams: 5000,
-        maxOutboundStreams: 5000,
         clientMode: true,
       }),
       identify: identify()

--- a/rust-peer/src/main.rs
+++ b/rust-peer/src/main.rs
@@ -34,7 +34,7 @@ use crate::protocol::FileRequest;
 
 const TICK_INTERVAL: Duration = Duration::from_secs(15);
 const KADEMLIA_PROTOCOL_NAME: StreamProtocol =
-    StreamProtocol::new("/universal-connectivity/lan/kad/1.0.0");
+    StreamProtocol::new("/ipfs/kad/1.0.0");
 const FILE_EXCHANGE_PROTOCOL: StreamProtocol =
     StreamProtocol::new("/universal-connectivity-file/1");
 const PORT_WEBRTC: u16 = 9090;


### PR DESCRIPTION
This PR changes the protocol ID used by the app to use the IPFS Kademlia DHT.


## Open Questions
- Why was a separate DHT id created for this app in the first place?
- What are the implications of using the IPFS DHT for this app if the presumption is that most users are browser users anyways

### What roles does the DHT play in this app
 
**Resolving bootstrap node PeerIDs to multiaddrs:** My original thinking was that the DHT would be used to make it easier to discover the multiaddrs of deployed Rust and Go peers which have an ephemeral (because of the temp cert which rotates) WebRTC-direct and WebTransport multiaddrs. That way, we can avoid [hardcoding ephemeral multiaddrs](https://github.com/libp2p/universal-connectivity/blob/use-ipfs-dht/js-peer/src/lib/constants.ts#L7-L8) in the frontend and instead just hardcode the PeerIDs which would be looked up in the DHT. Either way, browsers are still incapable of being reliable DHT clients due to transport constraints. 

By using the IPFS KAD DHT maybe we could lean on the [delegated routing endpoint](https://docs.ipfs.tech/concepts/public-utilities/#delegated-routing) in the browser to resolve bootstrap node PeerIDs to multiaddrs. That would require that the Go and Rust peers publish their multiaddrs to the DHT (which should be pretty simple)