### PR TITLE
feat: add bootstrap mode to go peer

### DIFF
--- a/js-peer/src/lib/libp2p.ts
+++ b/js-peer/src/lib/libp2p.ts
@@ -100,17 +100,17 @@ export async function startLibp2p(): Promise<Libp2pType> {
     log(`changed multiaddrs: peer ${peer.id.toString()} multiaddrs: ${multiaddrs}`)
   })
 
-  // 👇 explicitly dial peers discovered via pubsub
-  libp2p.addEventListener('peer:discovery', (event) => {
-    const { multiaddrs, id } = event.detail
-
-    if (libp2p.getConnections(id)?.length > 0) {
-      log(`Already connected to peer %s. Will not try dialling`, id)
-      return
-    }
-
-    dialWebRTCMaddrs(libp2p, multiaddrs)
-  })
+  // // 👇 explicitly dial peers discovered via pubsub
+  // libp2p.addEventListener('peer:discovery', (event) => {
+  //   const { multiaddrs, id } = event.detail
+  //
+  //   if (libp2p.getConnections(id)?.length > 0) {
+  //     log(`Already connected to peer %s. Will not try dialling`, id)
+  //     return
+  //   }
+  //
+  //   dialWebRTCMaddrs(libp2p, multiaddrs)
+  // })
 
   return libp2p
 }


### PR DESCRIPTION
* Add `bootstrapper` flag to go-peer
* Enable peer exchange in go-peer when bootstrapping
* Disable autodialing peers in js-peer - rely on PX from go bootstrapper instead