### PR TITLE
fix: only set circuit relay listen and simplify

### DIFF
--- a/js-peer/src/lib/libp2p.ts
+++ b/js-peer/src/lib/libp2p.ts
@@ -63,7 +63,7 @@ export async function startLibp2p(): Promise<Libp2pType> {
         interval: 10_000,
         topics: [PUBSUB_PEER_DISCOVERY],
         listenOnly: false,
-      })
+      }),
     ],
     services: {
       pubsub: gossipsub({
@@ -84,7 +84,6 @@ export async function startLibp2p(): Promise<Libp2pType> {
   if (!libp2p) {
     throw new Error('Failed to create libp2p node')
   }
-
 
   libp2p.services.pubsub.subscribe(CHAT_TOPIC)
   libp2p.services.pubsub.subscribe(CHAT_FILE_TOPIC)

--- a/js-peer/src/lib/libp2p.ts
+++ b/js-peer/src/lib/libp2p.ts
@@ -7,7 +7,6 @@ import { identify } from '@libp2p/identify'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { bootstrap } from '@libp2p/bootstrap'
 import { Multiaddr } from '@multiformats/multiaddr'
 import { sha256 } from 'multiformats/hashes/sha2'
 import type { Connection, Message, SignedMessage, PeerId, Libp2p } from '@libp2p/interface'
@@ -32,7 +31,7 @@ export async function startLibp2p(): Promise<Libp2pType> {
 
   const delegatedClient = createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev')
 
-  const { relayListenAddrs } = await getBootstrapMultiaddrs(delegatedClient)
+  const relayListenAddrs = await getBootstrapMultiaddrs(delegatedClient)
   log('starting libp2p with relayListenAddrs: %o', relayListenAddrs)
 
   let libp2p: Libp2pType


### PR DESCRIPTION
# What's in this PR

- Connect to the boostrapper only with ipv4 and websockets
- Remove the boostrap config. libp2p will connect to the peer anyways through the relayListenAddrs.