### PR TITLE
rust-peer: feat/rust/ping instead of identify

### DIFF
--- a/rust-peer/Cargo.lock
+++ b/rust-peer/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "rust-libp2p-webrtc-peer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust-peer/Cargo.toml
+++ b/rust-peer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-libp2p-webrtc-peer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-peer/src/main.rs
+++ b/rust-peer/src/main.rs
@@ -194,24 +194,6 @@ async fn main() -> Result<()> {
                 )) => {
                     debug!("{peer_id} subscribed to {topic}");
                 }
-                SwarmEvent::Behaviour(BehaviourEvent::Ping(ping::Event {
-                    peer,
-                    connection,
-                    result: Err(e),
-                    ..
-                })) => {
-                    // When a browser tab closes, we don't get a swarm event
-                    // maybe there's a way to get this with TransportEvent
-                    // but for now remove the peer from routing table if we fail to ping the other peer.
-
-                    // This isn't super clean because technically, other connections to this peer could still be functional.
-
-                    debug!("Connection {connection} to {peer} failed: {e}");
-                    swarm.close_connection(connection);
-                    swarm.behaviour_mut().kademlia.remove_peer(&peer);
-
-                    info!("Removed {peer} from routing table");
-                }
                 SwarmEvent::Behaviour(BehaviourEvent::Identify(e)) => {
                     info!("BehaviourEvent::Identify {:?}", e);
                     if let identify::Event::Received {


### PR DESCRIPTION
- **Replace identify timeout detection with ping**
- **Remove libp2p-ping**

Rebased version of #93 from @thomaseizinger on top of the current main.
