### PR TITLE
fix: add py-peer to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Realtime highly decentralised chat app.
 
 ![libp2p topology](libp2p-hero.svg)
 
-Showcasing [libp2p](https://libp2p.io/)'s superpowers in establishing ubiquitous peer-to-peer [connectivity](https://connectivity.libp2p.io/) in modern programming languages (Go, Rust, TypeScript) and runtimes (Web, native binary).
+Showcasing [libp2p](https://libp2p.io/)'s superpowers in establishing ubiquitous peer-to-peer [connectivity](https://connectivity.libp2p.io/) in modern programming languages (Go, Rust, TypeScript, Python) and runtimes (Web, native binary).
 
 On top of this strong foundation, it layers a GossipSub: A Secure PubSub Protocol for Unstructured Decentralised P2P Overlays. By analogy, an event broker with distributed brokering, or a distributed PubSub protocol.
 
@@ -25,6 +25,7 @@ Some of the cool and cutting-edge [transport protocols](https://connectivity.lib
 | [`js-peer`](./js-peer/)     | Browser Chat Peer in TypeScript | ✅           | ✅     | ✅            | ❌   | ❌  |
 | [`go-peer`](./go-peer/)     | Chat peer implemented in Go     | ✅           | ❌     | ✅            | ✅   | ✅  |
 | [`rust-peer`](./rust-peer/) | Chat peer implemented in Rust   | ❌           | ❌     | ✅            | ✅   | ❌  |
+| [`py-peer`](./py-peer/)     | Chat peer implemented in Python | ❌           | ❌     | ❌            | ❌   | ✅  |
 
 ✅ - Protocol supported
 ❌ - Protocol not supported
@@ -81,4 +82,13 @@ cargo run -- --help
 ```
 cd go-peer
 go run .
+```
+
+## Getting started: Python (Work in progress)
+
+The py-peer project uses [`uv`](https://docs.astral.sh/uv/) package manager. Make sure you have that installed per their instructions before continuing.
+
+```
+cd py-peer
+uv run hello.py
 ```


### PR DESCRIPTION
Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>

* add py-peer details to README.md

