### PR TITLE
fix: pin react-curse to 1.0.15

### DIFF
--- a/node-js-peer/package-lock.json
+++ b/node-js-peer/package-lock.json
@@ -27,49 +27,34 @@
         "multiformats": "^13.3.2",
         "protons-runtime": "^5.5.0",
         "react": "^18.3.1",
-        "react-curse": "^1.0.0",
+        "react-curse": "1.0.15",
         "uint8arraylist": "^2.4.8"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
         "@types/react": "^18.0.27",
-        "prettier": "3.4.2",
         "protons": "^7.6.0"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -77,22 +62,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -118,16 +103,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -135,14 +120,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.26.8",
-        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -161,30 +146,40 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -194,9 +189,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -204,27 +199,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -232,26 +227,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -316,13 +311,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -468,54 +463,44 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@babel/template": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -523,32 +508,32 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -561,9 +546,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@chainsafe/as-sha256": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.0.1.tgz",
-      "integrity": "sha512-4Y/kQm0LsJ6QRtGcMq6gOdQP+fZhWDfIV2eIqP6oFJZBWYGmdh3wm8YbrXDPLJO87X2Fu6koRLdUS00O3k14Hw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.2.0.tgz",
+      "integrity": "sha512-H2BNHQ5C3RS+H0ZvOdovK6GjFAyq5T6LClad8ivwj9Oaiy28uvdsGVS7gNJKuZmg0FGHAI+n7F0Qju6U0QkKDA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chainsafe/is-ip": {
@@ -598,21 +583,21 @@
       }
     },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-16.1.0.tgz",
-      "integrity": "sha512-GJA/i5pd6VmetxokvnPlEbVCeL7SfLHkSuUHwbJ4w0u7dZUbse4Hr8SA8RYGwNHbZr2TEKFC9WerhvMWbciIrQ==",
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-16.1.4.tgz",
+      "integrity": "sha512-f4FlyRVndcs4PoioOIZWrFc6wfO/mrAj7H63o0+eA0O2xhcoRkxHh6zna4W+WtScaF/Ua/UULgiNGuKNpLvLlQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/as-chacha20poly1305": "^0.1.0",
         "@chainsafe/as-sha256": "^1.0.0",
         "@libp2p/crypto": "^5.0.0",
-        "@libp2p/interface": "^2.0.0",
+        "@libp2p/interface": "^2.9.0",
         "@libp2p/peer-id": "^5.0.0",
         "@noble/ciphers": "^1.1.3",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
         "it-length-prefixed": "^10.0.1",
-        "it-length-prefixed-stream": "^1.0.0",
+        "it-length-prefixed-stream": "^2.0.1",
         "it-pair": "^2.0.6",
         "it-pipe": "^3.0.1",
         "it-stream-types": "^2.0.1",
@@ -640,36 +625,37 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic/-/libp2p-quic-1.1.1.tgz",
-      "integrity": "sha512-fnL6n82ngQ1qzcuI/bdVshHU/GumO4azloP3RG1z6hkmcro8gdVDAYgmP47rXOQUf2GlczwKyI2epIPMRVwDhg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic/-/libp2p-quic-1.1.3.tgz",
+      "integrity": "sha512-Y9F2vGPW5ZhvYYAcDC4dF6i92h+pch+BAXC1yfO2AX2KLyg8rVlECOkEffeStp06DL4knPZLN+Qi10EgOVfwwA==",
       "license": "MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.12",
-        "@libp2p/interface": "^2.6.0",
-        "@libp2p/utils": "^6.5.8",
+        "@libp2p/crypto": "^5.1.7",
+        "@libp2p/interface": "^2.10.5",
+        "@libp2p/utils": "^6.7.1",
         "@multiformats/multiaddr": "^12.4.0",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@multiformats/multiaddr-matcher": "^2.0.1",
         "it-stream-types": "^2.0.2",
+        "race-signal": "^1.1.3",
         "uint8arraylist": "^2.4.8"
       },
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@chainsafe/libp2p-quic-darwin-arm64": "1.1.1",
-        "@chainsafe/libp2p-quic-darwin-x64": "1.1.1",
-        "@chainsafe/libp2p-quic-linux-arm64-gnu": "1.1.1",
-        "@chainsafe/libp2p-quic-linux-arm64-musl": "1.1.1",
-        "@chainsafe/libp2p-quic-linux-x64-gnu": "1.1.1",
-        "@chainsafe/libp2p-quic-linux-x64-musl": "1.1.1",
-        "@chainsafe/libp2p-quic-win32-x64-msvc": "1.1.1"
+        "@chainsafe/libp2p-quic-darwin-arm64": "1.1.3",
+        "@chainsafe/libp2p-quic-darwin-x64": "1.1.3",
+        "@chainsafe/libp2p-quic-linux-arm64-gnu": "1.1.3",
+        "@chainsafe/libp2p-quic-linux-arm64-musl": "1.1.3",
+        "@chainsafe/libp2p-quic-linux-x64-gnu": "1.1.3",
+        "@chainsafe/libp2p-quic-linux-x64-musl": "1.1.3",
+        "@chainsafe/libp2p-quic-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/@chainsafe/libp2p-quic-darwin-arm64": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-darwin-arm64/-/libp2p-quic-darwin-arm64-1.1.1.tgz",
-      "integrity": "sha512-2INg6niu0u3GtKIsHC3gzEaufg/3ZgFvSeqIjuF+u5eXGIcTo1uare228icWC5/hn/DwQ83l6WafoMkuguSakA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-darwin-arm64/-/libp2p-quic-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-L9Ta/CalkCiKC910thxR6GfqD0Tmm8QfSbZ5eTY7sGUuYYeE5/73UOlNzVHZxEWid7uceYHBYETTAUkdSsy+RQ==",
       "cpu": [
         "arm64"
       ],
@@ -683,9 +669,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic-darwin-x64": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-darwin-x64/-/libp2p-quic-darwin-x64-1.1.1.tgz",
-      "integrity": "sha512-xHU6GqjI7/4daslX04VIjTrVxyb/O3Yc1hH2dubtEmqnpJEM5+7qf03MBK/ddNhbAqzC0b7QuU/ecEgtqjHsRA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-darwin-x64/-/libp2p-quic-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-hxE4wL/PQop/r6OLpzeJJ3c4WDtfk7zWBKhX2Zjul0jHc5v04a1DRTEmugooaqeU7UNnBQkBsqiHcA8efuhNqg==",
       "cpu": [
         "x64"
       ],
@@ -699,9 +685,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic-linux-arm64-gnu": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-arm64-gnu/-/libp2p-quic-linux-arm64-gnu-1.1.1.tgz",
-      "integrity": "sha512-HmjZ/2cb8xvkUBn1hPFkwl5s6m3hwkCiEE9ITlu/3UPajALpk4vrLjeoKDHV6M3c+ohIMauyKVqV50EEl6VM4Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-arm64-gnu/-/libp2p-quic-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-XUyafb32UHdkuhgNYATnoBj81YfRlVl1MDW+OPHD3XPsIYkloUHlPD9Y2cBH9m17K0lvhe/3KndeQ3WLZ2syNA==",
       "cpu": [
         "arm64"
       ],
@@ -715,9 +701,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic-linux-arm64-musl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-arm64-musl/-/libp2p-quic-linux-arm64-musl-1.1.1.tgz",
-      "integrity": "sha512-G7R4WhzDriLNpVRWPIlsyRUUDIik+4SJoX+ZKQ6T54r+wyJTght6coA1rJANjkXWa8wKK0b5iIQol1SZEGH3Jg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-arm64-musl/-/libp2p-quic-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-cmYfa3heaSUN/ts4P1Y1N72Oi7frQdufDC8KzBOgD5WVSLnpXw4Nq8mVt6kf7WU1FLC6FUffKuz3mRWse1gGVg==",
       "cpu": [
         "arm64"
       ],
@@ -731,9 +717,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic-linux-x64-gnu": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-x64-gnu/-/libp2p-quic-linux-x64-gnu-1.1.1.tgz",
-      "integrity": "sha512-ARZbIj+ueD/LTCwB7CLMtokNZkqu640gi9YIuhHqEqenLZ75FbpJpYnqY/Jx+vdK/+gV0NyRZ395o4pH1W5SXQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-x64-gnu/-/libp2p-quic-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-ZS4CtINANQeBvqVHAoWqW9SRfxZ9R5xbM1bQUPjjPsNWdIgu0vCjiIkRYqkaL9cJvVHJPguNhu/NwC6whkdWww==",
       "cpu": [
         "x64"
       ],
@@ -747,9 +733,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic-linux-x64-musl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-x64-musl/-/libp2p-quic-linux-x64-musl-1.1.1.tgz",
-      "integrity": "sha512-lsBlcYlukwTDupe9SxI7hmhhSlZfBhGWXlb4gRqd+xcBptadX15lPhJDBi6P9T2CMwsAIoZNLDZhMqPf8RL5fw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-linux-x64-musl/-/libp2p-quic-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-LRi33YOHa/s/KSVRV4iCK+Cz8VBg2J8j3KrUEPtUp3aQvxYYvA/YkbRBcRNOyvEz6natzYA8LOycQsJTrVt4MA==",
       "cpu": [
         "x64"
       ],
@@ -763,9 +749,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-quic-win32-x64-msvc": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-win32-x64-msvc/-/libp2p-quic-win32-x64-msvc-1.1.1.tgz",
-      "integrity": "sha512-5O5ffgtzD8fpb6LeP4/clscOdWk17JXrjfMTlp9zUtTa+0vcAzBT8RtWzv12Vaqf9PPsTp+dUQ5595LWMcZVEA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-quic-win32-x64-msvc/-/libp2p-quic-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-zm2h1lYkhHEcVrzO/D0NyPwf5yj0/4zWwltaHXl4fdQMy8kqJCm8zcyZmBRfniDX8/03a2svbYPZdTDtb7FSTw==",
       "cpu": [
         "x64"
       ],
@@ -779,9 +765,9 @@
       }
     },
     "node_modules/@chainsafe/libp2p-yamux": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-7.0.1.tgz",
-      "integrity": "sha512-949MI0Ll0AsYq1gUETZmL/MijwX0jilOQ1i4s8wDEXGiMhuPWWiMsPgEnX6n+VzFmTrfNYyGaaJj5/MqxV9y/g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-7.0.4.tgz",
+      "integrity": "sha512-Qw+EB9ew/9hRCq9V702gkm5xXThFHQ3Bdvh01M+enI1RScriSDWFGod02dwNHUxsYRc743i49sLlHp0edC7hSQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^2.0.0",
@@ -790,6 +776,7 @@
         "it-foreach": "^2.0.6",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.1",
+        "race-signal": "^1.1.3",
         "uint8arraylist": "^2.4.8"
       }
     },
@@ -1203,9 +1190,9 @@
       }
     },
     "node_modules/@helia/delegated-routing-v1-http-api-client": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@helia/delegated-routing-v1-http-api-client/-/delegated-routing-v1-http-api-client-4.2.2.tgz",
-      "integrity": "sha512-SQuyIZAbfvXUkGiralGI7sWq44Ztd1Cf+3pz/paCzq1J3Jvl7JnofWB0spsZjwSu0jYPdwAL60Nmg1TSTm6ZVg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@helia/delegated-routing-v1-http-api-client/-/delegated-routing-v1-http-api-client-4.2.5.tgz",
+      "integrity": "sha512-fFqVhs7a4TnpKQ1cZ4im3tj53v+8UZLFkQo85otl/GpbIVBmBoGbjkDHGPv4UdjJ2lmYM/cRdnHsYbfjuc5pwA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^2.2.0",
@@ -1225,13 +1212,13 @@
       }
     },
     "node_modules/@ipshipyard/node-datachannel": {
-      "version": "0.26.5",
-      "resolved": "https://registry.npmjs.org/@ipshipyard/node-datachannel/-/node-datachannel-0.26.5.tgz",
-      "integrity": "sha512-GOxqgCI4scLTSFwFO7ClK5eDgSCJQgf7mbmJu0qgPu9zNlRp0VJl6rNJScQBllHP7IhmBf3VXRWVvwWfOrplww==",
+      "version": "0.26.6",
+      "resolved": "https://registry.npmjs.org/@ipshipyard/node-datachannel/-/node-datachannel-0.26.6.tgz",
+      "integrity": "sha512-70HdhYMyAGXEMuCUq9ATO1Rx/JmiENM5LrGN94KT/q/Et2VsMjJpOWbyFzgodtkQJjDG5saNXTOiQpYZ1AnvEg==",
       "hasInstallScript": true,
       "license": "MPL 2.0",
       "dependencies": {
-        "prebuild-install": "^7.1.2"
+        "prebuild-install": "^7.1.3"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -1380,18 +1367,25 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1404,20 +1398,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1426,16 +1410,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1463,206 +1447,194 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/bootstrap": {
-      "version": "11.0.33",
-      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-11.0.33.tgz",
-      "integrity": "sha512-RQCHHlTx9jkZQY8k+qW/qkACmqBDD3Urzz/DwKLhnWubxz6ppG+QVnlQjfVArsH9jAUZ+t2m4RbklhdtcoZz2g==",
+      "version": "11.0.47",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-11.0.47.tgz",
+      "integrity": "sha512-D3V8AHZvX9R0cFD0BKmDp7fKTo+GgPFFWa55z62VP14yA3f3kSAELyZ7NujrD0QXEtUdd/d7suqeJ4tKGsnZ5A==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/peer-id": "^5.1.1",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/peer-id": "^5.1.9",
         "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.3.3"
+        "@multiformats/multiaddr": "^12.4.4",
+        "main-event": "^1.0.1"
       }
     },
     "node_modules/@libp2p/circuit-relay-v2": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-3.2.9.tgz",
-      "integrity": "sha512-raXe5HdAPbYBDaAt7uieHcq6nwlEac4JQBTRXlpD2Qq7XvvxOdpANPrfxDiZAZVhToKBJUwlEEbEqJ0dVUgWaA==",
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-3.2.24.tgz",
+      "integrity": "sha512-JXSm0dOOpPC+Yax0ngLYWqELHLFmaYPNZOhZkrr0iEtbiXwhDXuDuwT71pwmozp7h/rYd2YFoIk178AhZ4711Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/peer-collections": "^6.0.26",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/peer-record": "^8.0.26",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.3.3",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/peer-collections": "^6.0.35",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/peer-record": "^8.0.35",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^2.0.0",
         "any-signal": "^4.1.1",
-        "it-protobuf-stream": "^2.0.1",
+        "it-protobuf-stream": "^2.0.2",
         "it-stream-types": "^2.0.2",
-        "multiformats": "^13.3.1",
-        "nanoid": "^5.0.9",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
+        "nanoid": "^5.1.5",
         "progress-events": "^1.0.1",
         "protons-runtime": "^5.5.0",
-        "retimeable-signal": "^1.0.0",
+        "retimeable-signal": "^1.0.1",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.0.tgz",
-      "integrity": "sha512-hcmScz9m7Ae7R7b/w3x9DX+i60ZIUVsMmsHyIo0vSlGsxO0+tyM4UKUia5EpSp/i1SB/W1IFXxlURwpiX7R5eQ==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.8.tgz",
+      "integrity": "sha512-zkfWd2x12E0NbSRU52Wb0A5I9v5a1uLgCauR8uuTqnC21OVznXUGkMg4A2Xoj90M98lReDHo+Khc/hlQFbJ5Vw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@noble/curves": "^1.7.0",
-        "@noble/hashes": "^1.6.1",
-        "multiformats": "^13.3.1",
+        "@libp2p/interface": "^2.11.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "multiformats": "^13.3.6",
         "protons-runtime": "^5.5.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/identify": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-3.0.28.tgz",
-      "integrity": "sha512-cD+cZAEqfoqGa25t9HfEjjSz/G/DVHpxF0C4dd8qC7bOuQl2ylSub5fqppbZGgHbolJ2nolTDG+8r3Vqh18Nhw==",
+      "version": "3.0.39",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-3.0.39.tgz",
+      "integrity": "sha512-302y1LAGuPy8im+LUiB5+2sUOa/VZuAphOAKLsAQ/74EglWlSrw0Q7f09WUQvfNXmn7XpQnDh7GEI3NZBl54Jw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/peer-record": "^8.0.26",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.3.3",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
-        "it-drain": "^3.0.7",
-        "it-parallel": "^3.0.8",
-        "it-protobuf-stream": "^2.0.1",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/peer-record": "^8.0.35",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^2.0.0",
+        "it-drain": "^3.0.9",
+        "it-parallel": "^3.0.11",
+        "it-protobuf-stream": "^2.0.2",
+        "main-event": "^1.0.1",
         "protons-runtime": "^5.5.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.8.0.tgz",
-      "integrity": "sha512-QnIjqqUv2aDiBho6OGcNNhLT3Ac4RKrh41qoQmqG6csMRkUUx/xZMkfFJx3j0wGCIP8GS4sGspkTt4wCpPbSWw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.11.0.tgz",
+      "integrity": "sha512-0MUFKoXWHTQW3oWIgSHApmYMUKWO/Y02+7Hpyp+n3z+geD4Xo2Rku2gYWmxcq+Pyjkz6Q9YjDWz3Yb2SoV2E8Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^12.4.4",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.2",
-        "multiformats": "^13.3.1",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
         "progress-events": "^1.0.1",
         "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.10.tgz",
-      "integrity": "sha512-ULUilEvRUVMy0qB7VWkW0v7Ceg66VqkZ0pheff3gkHj5tXaH4VNE0SSFKfK7b8dK1Wd/HBwS2QheX5uLrEt84w==",
+      "version": "2.3.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.19.tgz",
+      "integrity": "sha512-v335EB0i5CaNF+0SqT01CTBp0VyjJizpy46KprcshFFjX16UQ8+/QzoTZqmot9WiAmAzwR0b87oKmlAE9cpxzQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/peer-collections": "^6.0.26",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/peer-collections": "^6.0.35",
+        "@multiformats/multiaddr": "^12.4.4",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/kad-dht": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-15.0.0.tgz",
-      "integrity": "sha512-DZk1MufQiXkefzjo6uCtpyZfqyso4Om2AO1456utZ4dK1+jlsrRozCG8j+cFk6CqNnyPOzk45Ds+a/AILACXBg==",
+      "version": "15.1.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-15.1.11.tgz",
+      "integrity": "sha512-a5sdnkztx8AVRDG/+llboRfTLkjQJpSPsSD6F/q6xlI2GbAyEf+JnNKJv0GAUZe9UJCl+g4htM1jA/Rjl0IuCg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/peer-collections": "^6.0.26",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/ping": "^2.0.28",
-        "@libp2p/record": "^4.0.5",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/peer-collections": "^6.0.35",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/ping": "^2.0.37",
+        "@libp2p/record": "^4.0.7",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
         "any-signal": "^4.1.1",
         "interface-datastore": "^8.3.1",
-        "it-all": "^3.0.6",
-        "it-drain": "^3.0.7",
-        "it-length": "^3.0.6",
-        "it-length-prefixed": "^10.0.1",
-        "it-map": "^3.1.1",
-        "it-merge": "^3.0.5",
-        "it-parallel": "^3.0.8",
+        "it-all": "^3.0.8",
+        "it-drain": "^3.0.9",
+        "it-length": "^3.0.8",
+        "it-map": "^3.1.3",
+        "it-merge": "^3.0.11",
+        "it-parallel": "^3.0.11",
         "it-pipe": "^3.0.1",
-        "it-protobuf-stream": "^2.0.1",
-        "it-take": "^3.0.6",
-        "mortice": "^3.0.6",
-        "multiformats": "^13.3.1",
+        "it-protobuf-stream": "^2.0.2",
+        "it-pushable": "^3.2.3",
+        "it-take": "^3.0.8",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
         "p-defer": "^4.0.1",
         "p-event": "^6.0.1",
         "progress-events": "^1.0.1",
         "protons-runtime": "^5.5.0",
-        "race-signal": "^1.1.2",
+        "race-signal": "^1.1.3",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/kad-dht/node_modules/it-length-prefixed": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-10.0.1.tgz",
-      "integrity": "sha512-BhyluvGps26u9a7eQIpOI1YN7mFgi8lFwmiPi07whewbBARKAG9LE09Odc8s1Wtbt2MB6rNUrl7j9vvfXTJwdQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-reader": "^6.0.1",
-        "it-stream-types": "^2.0.1",
-        "uint8-varint": "^2.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/keychain": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-5.2.0.tgz",
-      "integrity": "sha512-m/jJ58xYl4o5Z/pRXSZBv19OaNgETdgLtrLc2u+CzvEWLEJSCei1ws9y83t34NSdbznepTvATZtpeJrlsCSbLQ==",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-5.2.9.tgz",
+      "integrity": "sha512-BgZKMqQCu3Xzd7YFIdwWqG2xXtvsO6RVHJKS8VOw6Dg5tuPAWcQhs0T84TZ5PCg5r6NNBwwI8fWdZGVtu/pPfQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@noble/hashes": "^1.6.1",
-        "asn1js": "^3.0.5",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/utils": "^6.7.2",
+        "@noble/hashes": "^1.8.0",
+        "asn1js": "^3.0.6",
         "interface-datastore": "^8.3.1",
-        "merge-options": "^3.0.4",
-        "multiformats": "^13.3.1",
+        "multiformats": "^13.3.6",
         "sanitize-filename": "^1.6.3",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.14.tgz",
-      "integrity": "sha512-rJeEq7iuKMMjel0zzH10dXzcWn4Q2yywbv5vM9B1xTQpkD4uxTbBlQs+EL9+pmwaaQrrriEGqluZOTzHvUzJUg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.2.0.tgz",
+      "integrity": "sha512-OEFS529CnIKfbWEHmuCNESw9q0D0hL8cQ8klQfjIVPur15RcgAEgc1buQ7Y6l0B6tCYg120bp55+e9tGvn8c0g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/interface": "^2.11.0",
+        "@multiformats/multiaddr": "^12.4.4",
         "interface-datastore": "^8.3.1",
-        "multiformats": "^13.3.1",
+        "multiformats": "^13.3.6",
         "weald": "^1.0.4"
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "6.0.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-6.0.21.tgz",
-      "integrity": "sha512-l1c70p8ljrrqnm0y9m/3mvtkYhbGt5zPOpxRKVveWR2+OyqiPFa48uRktmpJcl4zwG5dHWMG/klhdHoNpetJpw==",
+      "version": "6.0.29",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-6.0.29.tgz",
+      "integrity": "sha512-SWQbPcABOIpznEY7+vAp0Y3HNrE2PlaVY4EywN0lUZ7zvTv9VnAb7av3/gMvfaLI+YrOvhCr1mZ9qbSB93k4kA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
+        "@libp2p/interface": "^2.11.0",
         "it-length-prefixed": "^10.0.1",
-        "it-length-prefixed-stream": "^2.0.1",
+        "it-length-prefixed-stream": "^2.0.2",
         "it-stream-types": "^2.0.2",
         "p-defer": "^4.0.1",
-        "race-signal": "^1.1.2",
+        "race-signal": "^1.1.3",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
@@ -1685,55 +1657,42 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/multistream-select/node_modules/it-length-prefixed-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-2.0.1.tgz",
-      "integrity": "sha512-TFohjVrQKRLQgRrPdVL9ARqP4CHUHnsRkbkX4nEhSOBjOvZtVV/pHh5Z2C8EH50MnfNDjVSKvEbaIFVLS3/QMA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "abort-error": "^1.0.1",
-        "it-byte-stream": "^2.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
     "node_modules/@libp2p/peer-collections": {
-      "version": "6.0.26",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.26.tgz",
-      "integrity": "sha512-bpo4Oim+pvZh6AiIPjYDVb2Us6siJnRBWmyEzrV5t+EmGdLUjOKmRD3NnBp2WoO3RYAMESDyBrpxjnZo5ydHCA==",
+      "version": "6.0.35",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.35.tgz",
+      "integrity": "sha512-QiloK3T7DXW7R2cpL38dBnALCHf5pMzs/TyFzlEK33WezA2YFVoj7CtOJKqbn29bmV9uspWOxMgfmLUXf8ALvA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/utils": "^6.6.1",
-        "multiformats": "^13.3.1"
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/utils": "^6.7.2",
+        "multiformats": "^13.3.6"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.1.tgz",
-      "integrity": "sha512-dVpgln2gWybglCC8hiQqyGlyXU7F7ovoOqwnnMs8HxurGEH9QxgmCfxRP4p8s86bQwl1MFbyj0AqYPy/zbKLrA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.9.tgz",
+      "integrity": "sha512-cVDp7lX187Epmi/zr0Qq2RsEMmueswP9eIxYSFoMcHL/qcvRFhsxOfUGB8361E26s2WJvC9sXZ0oJS9XVueJhQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "multiformats": "^13.3.1",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "multiformats": "^13.3.6",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.26.tgz",
-      "integrity": "sha512-uZrGsZ7JLwY2B60El60AGcYjdcB87J596vyY722adQshLLiTTafkEZeHDSVVC3k5R8EP0gwrIEidi3xtPYRT5w==",
+      "version": "8.0.35",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.35.tgz",
+      "integrity": "sha512-0818zvjKbucq5XBnusG8oSWxJ992rVry/2qlfcn/nyK/uDrZ12tjDYHNMCoOWTNeFvFUVkMg9pRkvXvTNp6Yiw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.3.3",
-        "multiformats": "^13.3.1",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
+        "multiformats": "^13.3.6",
         "protons-runtime": "^5.5.0",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
@@ -1741,64 +1700,68 @@
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-11.1.3.tgz",
-      "integrity": "sha512-RTSFHLXklOcGVXbuEZMfn4qFKxELGnSJkIRfh9RHxSWUbD8gwisrp9+Wecd9QYAu5sVeCmk2tPt/EhPdJDWCeQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-11.2.7.tgz",
+      "integrity": "sha512-dwTM+0i7mAgAnZvMHghgGcFoWPGaTbKx2nBueMd2Yg38mCs9WeambmR6gQdjwvYpybvNgFDAA+XesCKCotuczg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/peer-record": "^8.0.26",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/peer-collections": "^6.0.35",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/peer-record": "^8.0.35",
+        "@multiformats/multiaddr": "^12.4.4",
         "interface-datastore": "^8.3.1",
-        "it-all": "^3.0.6",
-        "mortice": "^3.0.6",
-        "multiformats": "^13.3.1",
+        "it-all": "^3.0.8",
+        "main-event": "^1.0.1",
+        "mortice": "^3.2.1",
+        "multiformats": "^13.3.6",
         "protons-runtime": "^5.5.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/ping": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-2.0.28.tgz",
-      "integrity": "sha512-blQN5SYNx2pZv/GZZz4/PSAnnsRoUAp5SnLyXp2c9+O1LmpdCEKsJ6OjOTM9d3grXJMMXrgAaq3IyQ1IJYIlKA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-2.0.37.tgz",
+      "integrity": "sha512-SvCYM/tHvK3LQzCEa4eflQmrHEL5EAPWPxbIclqJ6SA0mi7jW3xO21AIsHkQDxfFVevIRWKaKoLj6MAythrNcg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@multiformats/multiaddr": "^12.3.3",
-        "it-byte-stream": "^2.0.1",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@multiformats/multiaddr": "^12.4.4",
+        "it-byte-stream": "^2.0.2",
+        "main-event": "^1.0.1",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/pubsub": {
-      "version": "10.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-10.1.9.tgz",
-      "integrity": "sha512-8QZmkOs11kivHtxm02PT/HEdfuDEYeA+NEcW/Gdq/lle0W/5jLzHxAJ3DJBteRjYkvAfZqVx5I53DUaabQgYAA==",
+      "version": "10.1.18",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-10.1.18.tgz",
+      "integrity": "sha512-Bxa0cwkaQvadyJNlJlzH0m1eo7m03G2nCpuKbcv+i0qNbyyTOydBcuoslG/UWFYhRBB9Js9R6zNIsaIgpo+iGw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/peer-collections": "^6.0.26",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/utils": "^6.6.1",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/peer-collections": "^6.0.35",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/utils": "^6.7.2",
         "it-length-prefixed": "^10.0.1",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
-        "multiformats": "^13.3.1",
-        "p-queue": "^8.0.1",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
+        "p-queue": "^8.1.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/pubsub-peer-discovery": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub-peer-discovery/-/pubsub-peer-discovery-11.0.1.tgz",
-      "integrity": "sha512-bT7UO7tQ4mZCPFE0eS8Fx19B8MGzxjbTNR6SwcLGcOqOqUTvc2CLByMvcy3iMXuKjmds6G+VUf5ZMhvjGLTznA==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub-peer-discovery/-/pubsub-peer-discovery-11.0.2.tgz",
+      "integrity": "sha512-qN3bP7QX6KepuSBIqvbkoGnMJ6Oc5gV86+QXtNJh3T2lUV34kTsuIcROkMeBeYDOfzUi/99Y4LIOrtBOC3M3yA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/crypto": "^5.0.0",
@@ -1829,9 +1792,9 @@
       }
     },
     "node_modules/@libp2p/record": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-4.0.5.tgz",
-      "integrity": "sha512-HfKugY+ZKizhxE/hbLqI8zcFLfYly2gakaL0k8wBXCfmOTrAV7UajeJWkWqrKkIEMHASUyapm746KF+i9e7Xmw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-4.0.7.tgz",
+      "integrity": "sha512-9JFfOytFS730Z79azWi3Ozlb7IufpwbjC/frAv1yZUCLPp7flT9HNsNB+JQwi+V7z68MaNUYeAFE86VQaq2ccA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "protons-runtime": "^5.5.0",
@@ -1840,16 +1803,17 @@
       }
     },
     "node_modules/@libp2p/tcp": {
-      "version": "10.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-10.1.9.tgz",
-      "integrity": "sha512-bndo9rSD9hglgvTOOKOWMO9j5S479IwpkuL2hHBMEf5MkO/7B5DYW0cxg4GLdzcxSAgzD/lS96QAUa0ouOLRbQ==",
+      "version": "10.1.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-10.1.19.tgz",
+      "integrity": "sha512-Z+s1n7gBexc32d+DUhOGgQpA8HVukubmNJHzolzZPqly5DYkG2f6SIelitp+M5tDYOPH/43EH9pPSSZ3vUuOwQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.3.3",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
-        "@types/sinon": "^17.0.3",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^2.0.0",
+        "@types/sinon": "^17.0.4",
+        "main-event": "^1.0.1",
         "p-defer": "^4.0.1",
         "p-event": "^6.0.1",
         "progress-events": "^1.0.1",
@@ -1858,79 +1822,82 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.6.1.tgz",
-      "integrity": "sha512-7/oJ+GX+pvM8bDe55VsmpuuBZS/HIYp/+DCyHqnm6o6d6rFSpF/yuVhKGK29P0MNgApzHeHrwfnvzPXrz64d3A==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.7.2.tgz",
+      "integrity": "sha512-yglVPcYErb4al3MMTdedVLLsdUvr5KaqrrxohxTl/FXMFBvBs0o3w8lo29nfnTUpnNSHFhWZ9at0ZGNnpT/C/w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/is-ip": "^2.0.2",
+        "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/logger": "^5.1.14",
-        "@multiformats/multiaddr": "^12.3.3",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/logger": "^5.2.0",
+        "@multiformats/multiaddr": "^12.4.4",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
         "delay": "^6.0.0",
         "get-iterator": "^2.0.1",
         "is-loopback-addr": "^2.0.2",
-        "it-foreach": "^2.1.1",
+        "is-plain-obj": "^4.1.0",
+        "it-foreach": "^2.1.3",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.2",
+        "main-event": "^1.0.1",
         "netmask": "^2.0.2",
         "p-defer": "^4.0.1",
         "race-event": "^1.3.0",
-        "race-signal": "^1.1.2",
+        "race-signal": "^1.1.3",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/webrtc": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-5.2.10.tgz",
-      "integrity": "sha512-pbbU75aECXD+6glz4n/8o4NXMf+1BnbXWzyXoBOLeS3XxnR7o6jum8H38rzy+Gz1UOp2o7iEnRvfG82z9TAiMw==",
+      "version": "5.2.24",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-5.2.24.tgz",
+      "integrity": "sha512-0Ne/GDR0FBnKQ/KpJDdQ0Ohii1jyhSCJvbKRxLISm8XItCuJtE1WA2awiWZddZwp2lPDPh9iQmFaYUvv8Zel2w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/is-ip": "^2.0.2",
-        "@chainsafe/libp2p-noise": "^16.0.0",
-        "@ipshipyard/node-datachannel": "^0.26.4",
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/keychain": "^5.2.0",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.4.0",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@chainsafe/is-ip": "^2.1.0",
+        "@chainsafe/libp2p-noise": "^16.1.3",
+        "@ipshipyard/node-datachannel": "^0.26.6",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/keychain": "^5.2.9",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^2.0.0",
         "@peculiar/webcrypto": "^1.5.0",
-        "@peculiar/x509": "^1.11.0",
+        "@peculiar/x509": "^1.12.3",
         "any-signal": "^4.1.1",
         "detect-browser": "^5.3.0",
         "get-port": "^7.1.0",
         "interface-datastore": "^8.3.1",
         "it-length-prefixed": "^10.0.1",
-        "it-protobuf-stream": "^2.0.1",
+        "it-protobuf-stream": "^2.0.2",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.2",
-        "multiformats": "^13.3.1",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
         "p-defer": "^4.0.1",
-        "p-timeout": "^6.1.3",
+        "p-timeout": "^6.1.4",
         "p-wait-for": "^5.0.2",
         "progress-events": "^1.0.1",
         "protons-runtime": "^5.5.0",
         "race-event": "^1.3.0",
-        "race-signal": "^1.1.2",
-        "react-native-webrtc": "^124.0.4",
+        "race-signal": "^1.1.3",
+        "react-native-webrtc": "^124.0.5",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.0.tgz",
-      "integrity": "sha512-tCT1sHSI1O5KSclDwNfnkLTLe3cgiyYWjIlmNxWJHqhCCz017HGOS/oH0zs0ZgxYwN7xCzTkqY330XMDo+yj2g==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.1.tgz",
+      "integrity": "sha512-yG+zcMtyApW1yRwkNFvlXzEg3RIFdItuwr/zEvPCSdjaL+paX4rounpL0YX5kS9MsDIE5FXfcqINXg7L0xuwPg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1938,10 +1905,10 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
+        "@types/react": "^19.1.0",
         "react": "*",
         "react-native": "*"
       },
@@ -1952,9 +1919,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/@types/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
+      "version": "19.1.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
+      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1963,9 +1930,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1988,6 +1955,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@libp2p/webrtc/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/glob": {
@@ -2049,9 +2028,9 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/webrtc/node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2059,43 +2038,41 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/react-native": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.0.tgz",
-      "integrity": "sha512-fLG/zl/YF30TWTmp2bbo3flHSFGe4WTyVkb7/wJnMEC39jjXVSCxfDtvSUVavhCc03fA/RTkWWvlmg7NEJk7Vg==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.1.tgz",
+      "integrity": "sha512-k2QJzWc/CUOwaakmD1SXa4uJaLcwB2g2V9BauNIjgtXYYAeyFjx9jlNz/+wAEcHLg9bH5mgMdeAwzvXqjjh9Hg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.0",
-        "@react-native/codegen": "0.79.0",
-        "@react-native/community-cli-plugin": "0.79.0",
-        "@react-native/gradle-plugin": "0.79.0",
-        "@react-native/js-polyfills": "0.79.0",
-        "@react-native/normalize-colors": "0.79.0",
-        "@react-native/virtualized-lists": "0.79.0",
+        "@react-native/assets-registry": "0.81.1",
+        "@react-native/codegen": "0.81.1",
+        "@react-native/community-cli-plugin": "0.81.1",
+        "@react-native/gradle-plugin": "0.81.1",
+        "@react-native/js-polyfills": "0.81.1",
+        "@react-native/normalize-colors": "0.81.1",
+        "@react-native/virtualized-lists": "0.81.1",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "babel-plugin-syntax-hermes-parser": "0.29.1",
         "base64-js": "^1.5.1",
-        "chalk": "^4.0.0",
         "commander": "^12.0.0",
-        "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.82.0",
-        "metro-source-map": "^0.82.0",
+        "metro-runtime": "^0.83.1",
+        "metro-source-map": "^0.83.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^6.1.1",
+        "react-devtools-core": "^6.1.5",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.25.0",
+        "scheduler": "0.26.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
@@ -2106,11 +2083,11 @@
         "react-native": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "^19.0.0"
+        "@types/react": "^19.1.0",
+        "react": "^19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2119,9 +2096,9 @@
       }
     },
     "node_modules/@libp2p/webrtc/node_modules/react-native-webrtc": {
-      "version": "124.0.5",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.5.tgz",
-      "integrity": "sha512-LIQJKst+t53bJOcQef9VXuz3pVheSBUA4olQGkxosbF4pHW1gsWoXYmf6wmI2zrqOA+aZsjjB6aT9AKLyr6a0Q==",
+      "version": "124.0.6",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.6.tgz",
+      "integrity": "sha512-5GviOGK19vujT7sGvSYdZE+bBlh0KC9g1JLharzajpCDVrNdCSpYxveOJUINSRevLsmL12FgNJJgnTjFKn7Aqw==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",
@@ -2132,22 +2109,10 @@
         "react-native": ">=0.60.0"
       }
     },
-    "node_modules/@libp2p/webrtc/node_modules/react-native-webrtc/node_modules/event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
     "node_modules/@libp2p/webrtc/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT",
       "peer": true
     },
@@ -2162,32 +2127,32 @@
       }
     },
     "node_modules/@libp2p/websockets": {
-      "version": "9.2.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-9.2.9.tgz",
-      "integrity": "sha512-fXe/VmEuUCXseuJaUo9ZIK2LCIqxebWkg5kQOCFMt+HG2OeZ3uRNXKiCysoXDCmqb8iKnfGwbS3cf+14eI3UEQ==",
+      "version": "9.2.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-9.2.19.tgz",
+      "integrity": "sha512-+g2qI9Lgvyofoc6GFztPoPVZV+z/lg9pIUfneHht6j88Y7tH3NrAQ7Ki+9lqS5XBX2h1O1bHULWbCaVYCj9TZg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/utils": "^6.6.1",
-        "@multiformats/multiaddr": "^12.3.3",
-        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/utils": "^6.7.2",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^2.0.0",
         "@multiformats/multiaddr-to-uri": "^11.0.0",
-        "@types/ws": "^8.5.13",
+        "@types/ws": "^8.18.1",
         "it-ws": "^6.1.5",
+        "main-event": "^1.0.1",
         "p-defer": "^4.0.1",
         "p-event": "^6.0.1",
         "progress-events": "^1.0.1",
-        "race-signal": "^1.1.2",
-        "ws": "^8.18.0"
+        "race-signal": "^1.1.3",
+        "ws": "^8.18.2"
       }
     },
     "node_modules/@multiformats/dns": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
-      "integrity": "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.9.tgz",
+      "integrity": "sha512-Ja4hevWI9p96ICx11K3suFvFirnMmXILzS7FpsR2KG3FoKF/XJijm8ylf3vY6kRFGr98yfZYM+zIn18KaINs3A==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@types/dns-packet": "^5.6.5",
         "buffer": "^6.0.3",
         "dns-packet": "^5.6.1",
         "hashlru": "^2.3.0",
@@ -2206,43 +2171,42 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.4.0.tgz",
-      "integrity": "sha512-FL7yBTLijJ5JkO044BGb2msf+uJLrwpD6jD6TkXlbjA9N12+18HT40jvd4o5vL4LOJMc86dPX6tGtk/uI9kYKg==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
         "multiformats": "^13.0.0",
         "uint8-varint": "^2.0.1",
         "uint8arrays": "^5.0.0"
       }
     },
     "node_modules/@multiformats/multiaddr-matcher": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.7.0.tgz",
-      "integrity": "sha512-WfobrJy7XLaYL7PQ3IcFoXdGN5jmdv5FsuKQkZIIreC1pSR4Q9PSOWu2ULxP/M2JT738Xny0PFoCke0ENbyfww==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-2.0.2.tgz",
+      "integrity": "sha512-si7EZCI93mfBJKKRkh+u2bB9W6W5APVN3XfdwuseEJ0OS7ysg0Jno9SuAi0bRzsl5OEFESoF71SjsRqgp8PXAA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@multiformats/multiaddr": "^12.0.0",
-        "multiformats": "^13.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
       }
     },
     "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-11.0.0.tgz",
-      "integrity": "sha512-9RNmlIGwZbBLsHekT50dbt4o4u8Iciw9kGjv+WHiGxQdsJ6xKKjU1+C0Vbas6RilMbaVOAOnEyfNcXbUmTkLxQ==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-11.0.2.tgz",
+      "integrity": "sha512-SiLFD54zeOJ0qMgo9xv1Tl9O5YktDKAVDP4q4hL16mSq4O4sfFNagNADz8eAofxd6TfQUzGQ3TkRRG9IY2uHRg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/multiaddr": "^12.3.0"
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
-      "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2252,12 +2216,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2267,9 +2231,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2279,128 +2243,128 @@
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.15.tgz",
-      "integrity": "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.5.0.tgz",
+      "integrity": "sha512-p0SjJ3TuuleIvjPM4aYfvYw8Fk1Hn/zAVyPJZTtZ2eE9/MIer6/18ROxX6N/e6edVSfvuZBqhxAj3YgsmSjQ/A==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "@peculiar/asn1-x509-attr": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "@peculiar/asn1-x509-attr": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.15.tgz",
-      "integrity": "sha512-caxAOrvw2hUZpxzhz8Kp8iBYKsHbGXZPl2KYRMIPvAfFateRebS3136+orUpcVwHRmpXWX2kzpb6COlIrqCumA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.5.0.tgz",
+      "integrity": "sha512-ioigvA6WSYN9h/YssMmmoIwgl3RvZlAYx4A/9jD2qaqXZwGcNlAxaw54eSx2QG1Yu7YyBC5Rku3nNoHrQ16YsQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz",
-      "integrity": "sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.5.0.tgz",
+      "integrity": "sha512-t4eYGNhXtLRxaP50h3sfO6aJebUCDGQACoeexcelL4roMFRRVgB20yBIu2LxsPh/tdW9I282gNgMOyg3ywg/mg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.15.tgz",
-      "integrity": "sha512-E3kzQe3J2xV9DP6SJS4X6/N1e4cYa2xOAK46VtvpaRk8jlheNri8v0rBezKFVPB1rz/jW8npO+u1xOvpATFMWg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.5.0.tgz",
+      "integrity": "sha512-Vj0d0wxJZA+Ztqfb7W+/iu8Uasw6hhKtCdLKXLG/P3kEPIQpqGI4P4YXlROfl7gOCqFIbgsj1HzFIFwQ5s20ug==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.15",
-        "@peculiar/asn1-pkcs8": "^2.3.15",
-        "@peculiar/asn1-rsa": "^2.3.15",
-        "@peculiar/asn1-schema": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-cms": "^2.5.0",
+        "@peculiar/asn1-pkcs8": "^2.5.0",
+        "@peculiar/asn1-rsa": "^2.5.0",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.15.tgz",
-      "integrity": "sha512-/PuQj2BIAw1/v76DV1LUOA6YOqh/UvptKLJHtec/DQwruXOCFlUo7k6llegn8N5BTeZTWMwz5EXruBw0Q10TMg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.5.0.tgz",
+      "integrity": "sha512-L7599HTI2SLlitlpEP8oAPaJgYssByI4eCwQq2C9eC90otFpm8MRn66PpbKviweAlhinWQ3ZjDD2KIVtx7PaVw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.15.tgz",
-      "integrity": "sha512-yiZo/1EGvU1KiQUrbcnaPGWc0C7ElMMskWn7+kHsCFm+/9fU0+V1D/3a5oG0Jpy96iaXggQpA9tzdhnYDgjyFg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.5.0.tgz",
+      "integrity": "sha512-UgqSMBLNLR5TzEZ5ZzxR45Nk6VJrammxd60WMSkofyNzd3DQLSNycGWSK5Xg3UTYbXcDFyG8pA/7/y/ztVCa6A==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.15",
-        "@peculiar/asn1-pfx": "^2.3.15",
-        "@peculiar/asn1-pkcs8": "^2.3.15",
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "@peculiar/asn1-x509-attr": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-cms": "^2.5.0",
+        "@peculiar/asn1-pfx": "^2.5.0",
+        "@peculiar/asn1-pkcs8": "^2.5.0",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "@peculiar/asn1-x509-attr": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz",
-      "integrity": "sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.5.0.tgz",
+      "integrity": "sha512-qMZ/vweiTHy9syrkkqWFvbT3eLoedvamcUdnnvwyyUNv5FgFXA3KP8td+ATibnlZ0EANW5PYRm8E6MJzEB/72Q==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz",
-      "integrity": "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.5.0.tgz",
+      "integrity": "sha512-YM/nFfskFJSlHqv59ed6dZlLZqtZQwjRVJ4bBAiWV08Oc+1rSd5lDZcBEx0lGDHfSoH3UziI2pXt2UM33KerPQ==",
       "license": "MIT",
       "dependencies": {
-        "asn1js": "^3.0.5",
+        "asn1js": "^3.0.6",
         "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz",
-      "integrity": "sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.5.0.tgz",
+      "integrity": "sha512-CpwtMCTJvfvYTFMuiME5IH+8qmDe3yEWzKHe7OOADbGfq7ohxeLaXwQo0q4du3qs0AII3UbLCvb9NF/6q0oTKQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "asn1js": "^3.0.6",
         "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.15.tgz",
-      "integrity": "sha512-TWJVJhqc+IS4MTEML3l6W1b0sMowVqdsnI4dnojg96LvTuP8dga9f76fjP07MUuss60uSyT2ckoti/2qHXA10A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.5.0.tgz",
+      "integrity": "sha512-9f0hPOxiJDoG/bfNLAFven+Bd4gwz/VzrCIIWc1025LEI4BXO0U5fOCTNDPbbp2ll+UzqKsZ3g61mpBp74gk9A==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.15",
-        "@peculiar/asn1-x509": "^2.3.15",
-        "asn1js": "^3.0.5",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
@@ -2433,22 +2397,22 @@
       }
     },
     "node_modules/@peculiar/x509": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
-      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.0.tgz",
+      "integrity": "sha512-Yc4PDxN3OrxUPiXgU63c+ZRXKGE8YKF2McTciYhUHFtHVB0KMnjeFSU0qpztGhsp4P0uKix4+J2xEpIEDu8oXg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.13",
-        "@peculiar/asn1-csr": "^2.3.13",
-        "@peculiar/asn1-ecc": "^2.3.14",
-        "@peculiar/asn1-pkcs9": "^2.3.13",
-        "@peculiar/asn1-rsa": "^2.3.13",
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/asn1-x509": "^2.3.13",
-        "pvtsutils": "^1.3.5",
+        "@peculiar/asn1-cms": "^2.5.0",
+        "@peculiar/asn1-csr": "^2.5.0",
+        "@peculiar/asn1-ecc": "^2.5.0",
+        "@peculiar/asn1-pkcs9": "^2.5.0",
+        "@peculiar/asn1-rsa": "^2.5.0",
+        "@peculiar/asn1-schema": "^2.5.0",
+        "@peculiar/asn1-x509": "^2.5.0",
+        "pvtsutils": "^1.3.6",
         "reflect-metadata": "^0.2.2",
-        "tslib": "^2.7.0",
-        "tsyringe": "^4.8.0"
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2536,39 +2500,41 @@
       "peer": true
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.0.tgz",
-      "integrity": "sha512-Rwvpu3A05lM1HVlX4klH4UR52JbQPDKc8gi2mst2REZL1KeVgJRJxPPw8d8euVlYcq/s8XI1Ol827JaRtSZBTA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.1.tgz",
+      "integrity": "sha512-o/AeHeoiPW8x9MzxE1RSnKYc+KZMW9b7uaojobEz0G8fKgGD1R8n5CJSOiQ/0yO2fJdC5wFxMMOgy2IKwRrVgw==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.0.tgz",
-      "integrity": "sha512-D8bFlD0HH9SMUI00svdg64hEvLbu4ETeWQDlmEP8WmNbuILjwoLFqbnBmlGn69Tot0DM1PuBd1l1ooIzs8sU7w==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.1.tgz",
+      "integrity": "sha512-8KoUE1j65fF1PPHlAhSeUHmcyqpE+Z7Qv27A89vSZkz3s8eqWSRu2hZtCl0D3nSgS0WW0fyrIsFaRFj7azIiPw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.29.1",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2612,73 +2578,59 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.0.tgz",
-      "integrity": "sha512-pl+aSXxGj3ug80FpMDrArjxUbJWY2ibWiSP3MLKX+Xk7An2GUmFFjCzNVSbs0jzWv8814EG2oI60/GH2RXwE4g==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.1.tgz",
+      "integrity": "sha512-FuIpZcjBiiYcVMNx+1JBqTPLs2bUIm6X4F5enYGYcetNE2nfSMUVO8SGUtTkBdbUTfKesXYSYN8wungyro28Ag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.0",
-        "chalk": "^4.0.0",
-        "debug": "^2.2.0",
+        "@react-native/dev-middleware": "0.81.1",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.82.0",
-        "metro-config": "^0.82.0",
-        "metro-core": "^0.82.0",
+        "metro": "^0.83.1",
+        "metro-config": "^0.83.1",
+        "metro-core": "^0.83.1",
         "semver": "^7.1.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@react-native-community/cli": "*"
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "*"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
           "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
         }
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.0.tgz",
-      "integrity": "sha512-chwKEWAmQMkOKZWwBra+utquuJ/2uFqh+ZgZbJfNX+U0YsBx6AQ3dVbfAaXW3bSLYEJyf9Wb3Opsal4fmcD9Ww==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.81.1.tgz",
+      "integrity": "sha512-dwKv1EqKD+vONN4xsfyTXxn291CNl1LeBpaHhNGWASK1GO4qlyExMs4TtTjN57BnYHikR9PzqPWcUcfzpVRaLg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.0.tgz",
-      "integrity": "sha512-8Mh5L8zJXis2qhgkfXnWMbSmcvb07wrbxQe8KIgIO7C1rS97idg7BBtoPEtmARsaQgmbSGu/wdE7UWFkGYp0OQ==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.1.tgz",
+      "integrity": "sha512-hy3KlxNOfev3O5/IuyZSstixWo7E9FhljxKGHdvVtZVNjQdM+kPMh66mxeJbB2TjdJGAyBT4DjIwBaZnIFOGHQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.0",
+        "@react-native/debugger-frontend": "0.81.1",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
@@ -2686,25 +2638,8 @@
         "ws": "^6.2.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
       "version": "6.2.3",
@@ -2717,29 +2652,29 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.0.tgz",
-      "integrity": "sha512-c+/qKnmTx3kf8xZesp2BkZ9pAQVSnEPZziQUwviSJaq9jm8tKb/B8fyGG8yIuw/ZTKyGprD+ByzUSzJmCpC/Ow==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.81.1.tgz",
+      "integrity": "sha512-RpRxs/LbWVM9Zi5jH1qBLgTX746Ei+Ui4vj3FmUCd9EXUSECM5bJpphcsvqjxM5Vfl/o2wDLSqIoFkVP/6Te7g==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.0.tgz",
-      "integrity": "sha512-+8lk/zP90JC9xZBGhI8TPqqR1Y5dYXwXvfhXygr/LlHoo+H8TeQxcPrXWdT+PWOJl6Gf7dbCOGh9Std8J7CSQA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.81.1.tgz",
+      "integrity": "sha512-w093OkHFfCnJKnkiFizwwjgrjh5ra53BU0ebPM3uBLkIQ6ZMNSCTZhG8ZHIlAYeIGtEinvmnSUi3JySoxuDCAQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.0.tgz",
-      "integrity": "sha512-RmM7Dgb69a4qwdguKR+8MhT0u1IAKa/s0uy8/7JP9b/fm8zjUV9HctMgRgIpZTOELsowEyQodyTnhHQf4HPX0A==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.1.tgz",
+      "integrity": "sha512-TsaeZlE8OYFy3PSWc+1VBmAzI2T3kInzqxmwXoGU4w1d4XFkQFg271Ja9GmDi9cqV3CnBfqoF9VPwRxVlc/l5g==",
       "license": "MIT",
       "peer": true
     },
@@ -2818,22 +2753,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/types": "^7.20.7"
-      }
-    },
-    "node_modules/@types/dns-packet": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
-      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -2899,25 +2825,25 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
-      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3013,9 +2939,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3032,6 +2958,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/anser": {
@@ -3181,19 +3117,19 @@
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-parser": "0.25.1"
+        "hermes-parser": "0.29.1"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3214,7 +3150,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -3303,9 +3239,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3326,15 +3262,15 @@
       }
     },
     "node_modules/browser-readablestream-to-it": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.8.tgz",
-      "integrity": "sha512-+aDq+8QoTxIklc9m21oVg96Bm18EpeVke4/8vWPNu+9Ktd+G4PYavitE4gv/pjIndw1q+vxE/Rcnv1zYHrEQbQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.10.tgz",
+      "integrity": "sha512-I/9hEcRtjct8CzD9sVo9Mm4ntn0D+7tOVrjbPl69XAoOfgJ8NBdOQU+WX+5SHhcELJDb14mWt7zuvyqha+MEAQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3352,10 +3288,10 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
         "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3452,9 +3388,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001713",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3486,9 +3422,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.9.tgz",
-      "integrity": "sha512-HG8GprGhfzkbzDAIQApqYcN1BJAyf8vDQbzclAwaqrm3ATFnB7ygiWLr+YID+GBdfTJ+yHtzPi06218xULpZrg==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.15.tgz",
+      "integrity": "sha512-T+YVPemWyXcBVQdp0k61lQp2hJniRNmul0lAwTj2DTS/6dI4eCq/MRMucGqqvFqMBfmnD8tJ9aFtPu5dEGAbgw==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -3706,28 +3642,27 @@
       "license": "MIT"
     },
     "node_modules/datastore-core": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-10.0.2.tgz",
-      "integrity": "sha512-B3WXxI54VxJkpXxnYibiF17si3bLXE1XOjrJB7wM5co9fx2KOEkiePDGiCCEtnapFHTnmAnYCPdA7WZTIpdn/A==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-10.0.4.tgz",
+      "integrity": "sha512-IctgCO0GA7GHG7aRm3JRruibCsfvN4EXNnNIlLCZMKIv0TPkdAL5UFV3/xTYFYrrZ1jRNrXZNZRvfcVf/R+rAw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/logger": "^5.0.1",
+        "@libp2p/logger": "^5.1.18",
         "interface-datastore": "^8.0.0",
         "interface-store": "^6.0.0",
-        "it-drain": "^3.0.7",
-        "it-filter": "^3.1.1",
-        "it-map": "^3.1.1",
-        "it-merge": "^3.0.5",
+        "it-drain": "^3.0.9",
+        "it-filter": "^3.1.3",
+        "it-map": "^3.1.3",
+        "it-merge": "^3.0.11",
         "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
-        "it-sort": "^3.0.6",
-        "it-take": "^3.0.6"
+        "it-sort": "^3.0.8",
+        "it-take": "^3.0.8"
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3829,9 +3764,9 @@
       "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3857,9 +3792,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.135",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.135.tgz",
-      "integrity": "sha512-8gXUdEmvb+WCaYUhA0Svr08uSeRjM2w3x5uHOc1QbaEVzJXB8rgm5eptieXzyKoVEtinLvW6MtTcurA65PeS1Q==",
+      "version": "1.5.217",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.217.tgz",
+      "integrity": "sha512-Pludfu5iBxp9XzNl0qq2G87hdD17ZV7h5T4n6rQXDi3nCyloBV3jreE9+8GC6g4X/5yxqVgXEURpcLtM0WS4jA==",
       "license": "ISC",
       "peer": true
     },
@@ -3881,9 +3816,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4339,16 +4274,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4371,20 +4296,20 @@
       "license": "MIT"
     },
     "node_modules/hermes-estree": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.25.1"
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/http-errors": {
@@ -4412,6 +4337,20 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ieee754": {
@@ -4508,9 +4447,9 @@
       "license": "ISC"
     },
     "node_modules/interface-datastore": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.1.tgz",
-      "integrity": "sha512-3r0ETmHIi6HmvM5sc09QQiCD3gUfwtEM/AAChOyAd/UAKT69uk8LXfTSUBufbUIO/dU65Vj8nb9O6QjwW8vDSQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.2.tgz",
+      "integrity": "sha512-R3NLts7pRbJKc3qFdQf+u40hK8XWc0w4Qkx3OFEstC80VoaDUABY/dXA2EJPhtNC+bsrf41Ehvqb6+pnIclyRA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "interface-store": "^6.0.0",
@@ -4518,9 +4457,9 @@
       }
     },
     "node_modules/interface-store": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
-      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.3.tgz",
+      "integrity": "sha512-+WvfEZnFUhRwFxgz+QCQi7UC6o9AM0EHM9bpIe2Nhqb100NHCsTvNAn4eJgvgV2/tmLo1MP9nGxQKEcZTAueLA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/invariant": {
@@ -4534,9 +4473,9 @@
       }
     },
     "node_modules/ipns": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.0.2.tgz",
-      "integrity": "sha512-tokCgz9X678zvHnAabVG91K64X7HnHdWOrop0ghUcXkzH5XNsmxHwVpqVATNqq/w62h7fRDhWURHU/WOfYmCpA==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.2.tgz",
+      "integrity": "sha512-RKAX20vZSHWEobmUw4zpU8t/kw+0CkrJYMA5ou39kNW5B4sAPGOiR/wGK9c51tQKA3rb8SeKs5g7ndNvNiS/vg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/crypto": "^5.0.0",
@@ -4629,12 +4568,15 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -4688,15 +4630,15 @@
       }
     },
     "node_modules/it-all": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.7.tgz",
-      "integrity": "sha512-PkuYtu6XhJzuPTKXImd6y0qE6H91MUPV/b9xotXMAI6GjmD2v3NoHj2g5L0lS2qZ0EzyGWZU1kp0UxW8POvNBQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.9.tgz",
+      "integrity": "sha512-fz1oJJ36ciGnu2LntAlE6SA97bFZpW7Rnt0uEc1yazzR2nKokZLr8lIRtgnpex4NsmaBcvHF+Z9krljWFy/mmg==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-byte-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-2.0.1.tgz",
-      "integrity": "sha512-WccB179tWRNjTyXJ9wLshQdKSLdVIexmnNjLfCT7UnsiLisTVUY092YqFhkL+da1WFR0paGzB24L+pAzFhRI4Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-2.0.3.tgz",
+      "integrity": "sha512-h7FFcn4DWiWsJw1dCJhuPdiY8cGi1z8g4aLAfFspTaJbwQxvEMlEBFG/f8lIVGwM8YK26ClM4/9lxLVhF33b8g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "abort-error": "^1.0.1",
@@ -4707,39 +4649,39 @@
       }
     },
     "node_modules/it-drain": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.8.tgz",
-      "integrity": "sha512-eeOz+WwKc11ou1UuqZympcXPLCjpTn5ALcYFJiHeTEiYEZ2py/J1vq41XWYj88huCUiqp9iNHfObOKrbIk5Izw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.10.tgz",
+      "integrity": "sha512-0w/bXzudlyKIyD1+rl0xUKTI7k4cshcS43LTlBiGFxI8K1eyLydNPxGcsVLsFVtKh1/ieS8AnVWt6KwmozxyEA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-filter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.2.tgz",
-      "integrity": "sha512-2AozaGjIvBBiB7t7MpVNug9kwofqmKSpvgW7zhuyvCs6xxDd6FrfvqyfYtlQTKLNP+Io1WeXko1UQhdlK4M0gg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.4.tgz",
+      "integrity": "sha512-80kWEKgiFEa4fEYD3mwf2uygo1dTQ5Y5midKtL89iXyjinruA/sNXl6iFkTcdNedydjvIsFhWLiqRPQP4fAwWQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
       }
     },
     "node_modules/it-first": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.7.tgz",
-      "integrity": "sha512-e2dVSlOP+pAxPYPVJBF4fX7au8cvGfvLhIrGCMc5aWDnCvwgOo94xHbi3Da6eXQ2jPL5FGEM8sJMn5uE8Seu+g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.9.tgz",
+      "integrity": "sha512-ZWYun273Gbl7CwiF6kK5xBtIKR56H1NoRaiJek2QzDirgen24u8XZ0Nk+jdnJSuCTPxC2ul1TuXKxu/7eK6NuA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-foreach": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.2.tgz",
-      "integrity": "sha512-PvXs3v1FaeWDhWzRxnwB4vSKJngxdLgi0PddkfurCvIFBmKTBfWONLeyDk5dxrvtCzdE4y96KzEQynk4/bbI5A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.4.tgz",
+      "integrity": "sha512-gFntBbNLpVK9uDmaHusugICD8/Pp+OCqbF5q1Z8K+B8WaG20YgMePWbMxI1I25+JmNWWr3hk0ecKyiI9pOLgeA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
       }
     },
     "node_modules/it-length": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.7.tgz",
-      "integrity": "sha512-URrszwrzPrUn6PtsSFcixG4NwHydaARmPubO0UUnFH+NSNylBaGtair1fnxX7Zf2qVJQltPBVs3PZvcmFPTLXA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.9.tgz",
+      "integrity": "sha512-cPhRPzyulYqyL7x4sX4MOjG/xu3vvEIFAhJ1aCrtrnbfxloCOtejOONib5oC3Bz8tLL6b6ke6+YHu4Bm6HCG7A==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-length-prefixed": {
@@ -4760,60 +4702,40 @@
       }
     },
     "node_modules/it-length-prefixed-stream": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.2.1.tgz",
-      "integrity": "sha512-FYqlxc2toUoK+aPO5r3KDBIUG1mOvk2DzmjQcsfLUTHRWMJP4Va9855tVzg/22Bj+VUUaT7gxBg7HmbiCxTK4w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-2.0.3.tgz",
+      "integrity": "sha512-Ns3jNFy2mcFnV59llCYitJnFHapg8wIcOsWkEaAwOkG9v4HBCk24nze/zGDQjiJdDTyFXTT5GOY3M/uaksot3w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-byte-stream": "^1.0.0",
+        "abort-error": "^1.0.1",
+        "it-byte-stream": "^2.0.0",
         "it-stream-types": "^2.0.2",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8"
       }
     },
-    "node_modules/it-length-prefixed-stream/node_modules/it-byte-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
-      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "it-queueless-pushable": "^1.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/it-length-prefixed-stream/node_modules/it-queueless-pushable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.2.tgz",
-      "integrity": "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "p-defer": "^4.0.1",
-        "race-signal": "^1.1.3"
-      }
-    },
     "node_modules/it-map": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.2.tgz",
-      "integrity": "sha512-G3dzFUjTYHKumJJ8wa9dSDS3yKm8L7qDUnAgzemOD0UMztwm54Qc2v97SuUCiAgbOz/aibkSLImfoFK09RlSFQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.4.tgz",
+      "integrity": "sha512-QB9PYQdE9fUfpVFYfSxBIyvKynUCgblb143c+ktTK6ZuKSKkp7iH58uYFzagqcJ5HcqIfn1xbfaralHWam+3fg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
       }
     },
     "node_modules/it-merge": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.9.tgz",
-      "integrity": "sha512-TjY4WTiwe4ONmaKScNvHDAJj6Tw0UeQFp4JrtC/3Mq7DTyhytes7mnv5OpZV4gItpZcs0AgRntpT2vAy2cnXUw==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.12.tgz",
+      "integrity": "sha512-nnnFSUxKlkZVZD7c0jYw6rDxCcAQYcMsFj27thf7KkDhpj0EA0g9KHPxbFzHuDoc6US2EPS/MtplkNj8sbCx4Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-queueless-pushable": "^2.0.0"
       }
     },
     "node_modules/it-ndjson": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.1.2.tgz",
-      "integrity": "sha512-TPKpdYSNKjDdroCPnLamM5Up6XnPQ7F1KgNP3Ib5y5O4ayOVP+DHac/pzjUigcg9Kf9gkGVXDz8+FFKpWwoB3w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.1.4.tgz",
+      "integrity": "sha512-ZMgTUrNo/UQCeRUT3KqnC0UaClzU6D+ItSmzVt7Ks7pcJ7DboYeYBSPeFLAaEthf5zlvaApDuACLmOWepgkrRg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arraylist": "^2.4.8"
@@ -4834,18 +4756,18 @@
       }
     },
     "node_modules/it-parallel": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.9.tgz",
-      "integrity": "sha512-FSg8T+pr7Z1VUuBxEzAAp/K1j8r1e9mOcyzpWMxN3mt33WFhroFjWXV1oYSSjNqcdYwxD/XgydMVMktJvKiDog==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.13.tgz",
+      "integrity": "sha512-85PPJ/O8q97Vj9wmDTSBBXEkattwfQGruXitIzrh0RLPso6RHfiVqkuTqBNufYYtB1x6PSkh0cwvjmMIkFEPHA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.1"
       }
     },
     "node_modules/it-peekable": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.6.tgz",
-      "integrity": "sha512-odk9wn8AwFQipy8+tFaZNRCM62riraKZJRysfbmOett9wgJumCwgZFzWUBUwMoiQapEcEVGwjDpMChZIi+zLuQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.8.tgz",
+      "integrity": "sha512-7IDBQKSp/dtBxXV3Fj0v3qM1jftJ9y9XrWLRIuU1X6RdKqWiN60syNwP0fiDxZD97b8SYM58dD3uklIk1TTQAw==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-pipe": {
@@ -4864,27 +4786,14 @@
       }
     },
     "node_modules/it-protobuf-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-2.0.1.tgz",
-      "integrity": "sha512-szhw8w2aIENUa1yv0vFgGZDs7e81dQ/7dM10c4Rf6+rs5tqzWVCSLbpgxIYM0cA8KlcI66XGdzu6lyYp6jKdvw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-2.0.3.tgz",
+      "integrity": "sha512-Dus9qyylOSnC7l75/3qs6j3Fe9MCM2K5luXi9o175DYijFRne5FPucdOGIYdwaDBDQ4Oy34dNCuFobOpcusvEQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "abort-error": "^1.0.1",
         "it-length-prefixed-stream": "^2.0.0",
         "it-stream-types": "^2.0.2",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/it-protobuf-stream/node_modules/it-length-prefixed-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-2.0.1.tgz",
-      "integrity": "sha512-TFohjVrQKRLQgRrPdVL9ARqP4CHUHnsRkbkX4nEhSOBjOvZtVV/pHh5Z2C8EH50MnfNDjVSKvEbaIFVLS3/QMA==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "abort-error": "^1.0.1",
-        "it-byte-stream": "^2.0.0",
-        "it-stream-types": "^2.0.2",
-        "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8"
       }
     },
@@ -4897,10 +4806,23 @@
         "p-defer": "^4.0.0"
       }
     },
+    "node_modules/it-queue": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-queue/-/it-queue-1.1.0.tgz",
+      "integrity": "sha512-aK9unJRIaJc9qiv53LByhF7/I2AuD7Ro4oLfLieVLL9QXNvRx++ANMpv8yCp2UO0KAtBuf70GOxSYb6ElFVRpQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "abort-error": "^1.0.1",
+        "it-pushable": "^3.2.3",
+        "main-event": "^1.0.0",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.1.3"
+      }
+    },
     "node_modules/it-queueless-pushable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-2.0.0.tgz",
-      "integrity": "sha512-MlNnefWT/ntv5fesrHpxwVIu6ZdtlkN0A4aaJiE5wnmPMBv9ttiwX3UEMf78dFwIj5ZNaU9usYXg4swMEpUNJQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-2.0.2.tgz",
+      "integrity": "sha512-2BqIt7XvDdgEgudLAdJkdseAwbVSBc0yAd8yPVHrll4eBuJPWIj9+8C3OIxzEKwhswLtd3bi+yLrzgw9gCyxMA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "abort-error": "^1.0.1",
@@ -4923,9 +4845,9 @@
       }
     },
     "node_modules/it-sort": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.7.tgz",
-      "integrity": "sha512-PsaKSd2Z0uhq8Mq5htdfsE/UagmdLCLWdBXPwi3FZGR4BTG180pFamhK+O+luFtBCNGRoqKAdtbZGTyGwA9uzw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.9.tgz",
+      "integrity": "sha512-jsM6alGaPiQbcAJdzMsuMh00uJcI+kD9TBoScB8TR75zUFOmHvhSsPi+Dmh2zfVkcoca+14EbfeIZZXTUGH63w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-all": "^3.0.0"
@@ -4938,9 +4860,9 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-take": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.7.tgz",
-      "integrity": "sha512-0+EbsTvH1XCpwhhFkjWdqJTjzS5XP3KL69woBqwANNhMLKn0j39jk/WHIlvbg9XW2vEm7cZz4p8w5DkBZR8LoA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.9.tgz",
+      "integrity": "sha512-XMeUbnjOcgrhFXPUqa7H0VIjYSV/BvyxxjCp76QHVAFDJw2LmR1SHxUFiqyGeobgzJr7P2ZwSRRJQGn4D2BVlA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-ws": {
@@ -5286,38 +5208,38 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-2.8.3.tgz",
-      "integrity": "sha512-ety0Q5cO7TsA3TfozWfx4Z1vRaD3rSuuAF/sH4eNHSTUB47CrqBAUcPARJobuhg7j1A2NVIn+KU47KKJRvg6gQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-2.10.0.tgz",
+      "integrity": "sha512-tgDz7YuGg1XX7UfxebCUii+IGsly/8V0ZRZdFJSDySY2i3UuqpCTsEbRApH3cBKFhcAf00nx9xj8GL9zfo+XWw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/is-ip": "^2.0.2",
+        "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.1.0",
-        "@libp2p/interface": "^2.8.0",
-        "@libp2p/interface-internal": "^2.3.10",
-        "@libp2p/logger": "^5.1.14",
-        "@libp2p/multistream-select": "^6.0.21",
-        "@libp2p/peer-collections": "^6.0.26",
-        "@libp2p/peer-id": "^5.1.1",
-        "@libp2p/peer-store": "^11.1.3",
-        "@libp2p/utils": "^6.6.1",
+        "@libp2p/crypto": "^5.1.8",
+        "@libp2p/interface": "^2.11.0",
+        "@libp2p/interface-internal": "^2.3.19",
+        "@libp2p/logger": "^5.2.0",
+        "@libp2p/multistream-select": "^6.0.29",
+        "@libp2p/peer-collections": "^6.0.35",
+        "@libp2p/peer-id": "^5.1.9",
+        "@libp2p/peer-store": "^11.2.7",
+        "@libp2p/utils": "^6.7.2",
         "@multiformats/dns": "^1.0.6",
-        "@multiformats/multiaddr": "^12.3.5",
-        "@multiformats/multiaddr-matcher": "^1.7.0",
+        "@multiformats/multiaddr": "^12.4.4",
+        "@multiformats/multiaddr-matcher": "^2.0.0",
         "any-signal": "^4.1.1",
         "datastore-core": "^10.0.2",
         "interface-datastore": "^8.3.1",
-        "it-byte-stream": "^2.0.1",
-        "it-merge": "^3.0.5",
-        "it-parallel": "^3.0.8",
-        "merge-options": "^3.0.4",
-        "multiformats": "^13.3.1",
+        "it-byte-stream": "^2.0.2",
+        "it-merge": "^3.0.11",
+        "it-parallel": "^3.0.11",
+        "main-event": "^1.0.1",
+        "multiformats": "^13.3.6",
         "p-defer": "^4.0.1",
         "p-retry": "^6.2.1",
         "progress-events": "^1.0.1",
         "race-event": "^1.3.0",
-        "race-signal": "^1.1.2",
+        "race-signal": "^1.1.3",
         "uint8arrays": "^5.1.0"
       }
     },
@@ -5387,9 +5309,9 @@
       "peer": true
     },
     "node_modules/long": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
-      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -5415,6 +5337,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/main-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.1.tgz",
+      "integrity": "sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -5469,9 +5397,9 @@
       }
     },
     "node_modules/marky": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0",
       "peer": true
     },
@@ -5502,18 +5430,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5522,9 +5438,9 @@
       "peer": true
     },
     "node_modules/metro": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.1.tgz",
-      "integrity": "sha512-/avNIHMlZhkDRl5ZMKNGuZSFZU56M3ABtt/JFQBJWEnitHtSD3Qidnfgjglq61yDbsWBv7aVrOFhdPRPTHN92A==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.1.tgz",
+      "integrity": "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5543,24 +5459,24 @@
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.29.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.82.1",
-        "metro-cache": "0.82.1",
-        "metro-cache-key": "0.82.1",
-        "metro-config": "0.82.1",
-        "metro-core": "0.82.1",
-        "metro-file-map": "0.82.1",
-        "metro-resolver": "0.82.1",
-        "metro-runtime": "0.82.1",
-        "metro-source-map": "0.82.1",
-        "metro-symbolicate": "0.82.1",
-        "metro-transform-plugins": "0.82.1",
-        "metro-transform-worker": "0.82.1",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-config": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-file-map": "0.83.1",
+        "metro-resolver": "0.83.1",
+        "metro-runtime": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-symbolicate": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
+        "metro-transform-worker": "0.83.1",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -5573,57 +5489,58 @@
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.1.tgz",
-      "integrity": "sha512-SuDMRdJKafSj9mzIijCNRxVXWrlJZdTnVE9iTGHO85UFTp/mWOLftqCjEtEjc78/0Wq3Y8IoYayx/VkYmKUf/g==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz",
+      "integrity": "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.29.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.1.tgz",
-      "integrity": "sha512-4ZK5EdgM8bTLLjpPCYOImirXUXVZpUU/I81BeAkScF8FFJfEHhV8yFyVp4/689bLbUBMwqz3rvYyxnrMi242lA==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.1.tgz",
+      "integrity": "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
-        "metro-core": "0.82.1"
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.83.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.1.tgz",
-      "integrity": "sha512-RoByg/cxJUewdO4yDx3udpxc6S59570Ub34Jm2gjvOcYQOkGxNepNgyhWFlZLM7P7aBF2UwdCqDB1hoTRtQqNw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.1.tgz",
+      "integrity": "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.1.tgz",
-      "integrity": "sha512-+w3280sUdZmEDpmEhk66vfeWs8xKhogiPim+JT6AIhrTUS4exki+yFgXDdnBXrjvAvhxUtCZcoIueFKCC/mbZw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.1.tgz",
+      "integrity": "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5631,34 +5548,34 @@
         "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.82.1",
-        "metro-cache": "0.82.1",
-        "metro-core": "0.82.1",
-        "metro-runtime": "0.82.1"
+        "metro": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-runtime": "0.83.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.1.tgz",
-      "integrity": "sha512-C1a8lPGJPs6axj9q+qLSdzK98TYjjXV6nsGnTvYuSwwXAm5sS03ewZCDimRfzu1s58oR0O28QddBgxNtYpDnJg==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.1.tgz",
+      "integrity": "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.1"
+        "metro-resolver": "0.83.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.1.tgz",
-      "integrity": "sha512-6RgYYrkswBCH4GwbLiK6QGzTjNnlCdU7BwwZlf+14ApjUlbr1oBkwmAa6lMfmqfZuh2H/ET8X950kJ8uZavJNA==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.1.tgz",
+      "integrity": "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5673,13 +5590,13 @@
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.1.tgz",
-      "integrity": "sha512-3P2PY+9L9sKrlxWWAOb1Bi6HXFCdnevym1R/6stkev/kl1+khkrDs1Z40139fLXFZbn8FrvXe89sTFRC3vB+Nw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.1.tgz",
+      "integrity": "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5687,26 +5604,26 @@
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.1.tgz",
-      "integrity": "sha512-TnHK2FRTq/KMRZTqUKRXGJ4NGwJEHrPuo60UPGMUHzAS9diI22oCQ8y9888saGiXE+gi0Iplv/6AUTISxDgXqA==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.1.tgz",
+      "integrity": "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.1.tgz",
-      "integrity": "sha512-Xg7FccIHlNtI63RX0vKmIzXlM5eSq4mjMo0ALbxXpds/P4JVT0JeJW/BqwpncKabrpbZyvPmPguhd32TiMWHXg==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.1.tgz",
+      "integrity": "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5714,13 +5631,13 @@
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.1.tgz",
-      "integrity": "sha512-uCf60ybpmPvkkqQpVWtPZFCIMBS1D9uQ4r2isbqWvDQ1FFTi3xrhT1Z35Dyg30RQV6638XJ4wZY+Dwh8bU9W8A==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.1.tgz",
+      "integrity": "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5729,14 +5646,14 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.1",
+        "metro-symbolicate": "0.83.1",
         "nullthrows": "^1.1.1",
-        "ob1": "0.82.1",
+        "ob1": "0.83.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
@@ -5750,15 +5667,15 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.1.tgz",
-      "integrity": "sha512-UFofSe+y0tz+nQ5XOkgXOYu5xlbX/8jEvd2eSrd8SjAX7eAjbGwN0Kjji+87jSaMJIvRHkArVMWqwF6fZVq55g==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.1.tgz",
+      "integrity": "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.82.1",
+        "metro-source-map": "0.83.1",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -5767,7 +5684,7 @@
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
@@ -5781,9 +5698,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.1.tgz",
-      "integrity": "sha512-AHFattUD9tUjG2MFV4RgZRgZZNfdRVQ7X6+ORK3cqwiItMcY2mK7psC6G2zI3WOtbydBcu/xWTilmjl7krC7FQ==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.1.tgz",
+      "integrity": "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5795,13 +5712,13 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.1.tgz",
-      "integrity": "sha512-2vaadziCaYPfPMnl3tuYimjR7Gmj5CVOcQh/bJniOiXWZ0b1v4JGcw6jOAWzQKgNJdrOq8lMfzdT3xJ/cn/m7g==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.1.tgz",
+      "integrity": "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5810,17 +5727,17 @@
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.82.1",
-        "metro-babel-transformer": "0.82.1",
-        "metro-cache": "0.82.1",
-        "metro-cache-key": "0.82.1",
-        "metro-minify-terser": "0.82.1",
-        "metro-source-map": "0.82.1",
-        "metro-transform-plugins": "0.82.1",
+        "metro": "0.83.1",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-minify-terser": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro/node_modules/ci-info": {
@@ -5965,29 +5882,29 @@
       "license": "MIT"
     },
     "node_modules/mortice": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.6.tgz",
-      "integrity": "sha512-xUjsTQreX8rO3pHuGYDZ3PY/sEiONIzqzjLeog5akdY4bz9TlDDuvYlU8fm+6qnm4rnpa6AFxLhsfSBThLijdA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.3.1.tgz",
+      "integrity": "sha512-t3oESfijIPGsmsdLEKjF+grHfrbnKSXflJtgb1wY14cjxZpS6GnhHRXTxxzCAoCCnq1YYfpEPwY3gjiCPhOufQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "observable-webworkers": "^2.0.1",
-        "p-queue": "^8.0.1",
-        "p-timeout": "^6.0.0"
+        "abort-error": "^1.0.0",
+        "it-queue": "^1.1.0",
+        "main-event": "^1.0.0"
       }
     },
     "node_modules/ms": {
-      "version": "3.0.0-canary.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "version": "3.0.0-canary.202508261828",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.202508261828.tgz",
+      "integrity": "sha512-NotsCoUCIUkojWCzQff4ttdCfIPoA1UGZsyQbi7KmqkNRfKCrvga8JJi2PknHymHOuor0cJSn/ylj52Cbt2IrQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13"
+        "node": ">=18"
       }
     },
     "node_modules/multiformats": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.2.tgz",
-      "integrity": "sha512-qbB0CQDt3QKfiAzZ5ZYjLFOs+zW43vA4uyM8g27PeEuXZybUOFyjrVdP93HPBHMoglibwfkdVwbzfUq8qGcH6g==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.0.tgz",
+      "integrity": "sha512-Mkb/QcclrJxKC+vrcIFl297h52QcKh2Az/9A5vbWytbQt4225UWWWmIuSsKksdww9NkIeYcA7DkfftyLuC/JSg==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/nanoid": {
@@ -6034,9 +5951,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.74.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -6053,9 +5970,9 @@
       "peer": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
+      "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
       "license": "MIT",
       "peer": true
     },
@@ -6077,26 +5994,16 @@
       "peer": true
     },
     "node_modules/ob1": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.1.tgz",
-      "integrity": "sha512-J4m1GAoMC0673H8LmVolj7ZERYEwJWRR4/A/M8ZB5iK9BiFLeAkjvny/VGk3XOYiMtnvq7TV6oc3MfDJ8uKpFw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.1.tgz",
+      "integrity": "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
-      }
-    },
-    "node_modules/observable-webworkers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
-      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw==",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/on-finished": {
@@ -6213,9 +6120,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
-      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -6391,22 +6298,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -6452,9 +6343,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -6507,9 +6398,9 @@
       }
     },
     "node_modules/protons": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-7.6.0.tgz",
-      "integrity": "sha512-cq07hf6mZ3RykLAw++N2AXicTrjpj6Sf4crXBM1r6UG3YHd0hHiMt24+aMtglpMKLTVb2GmfHcyX+LrkpBgu2A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-7.7.0.tgz",
+      "integrity": "sha512-M17M/UBT+jHeleDioZf53FhdoXJdP7L1LUkjEqhPHK7aSeYW7FDoCZETEjzTap9Knq4KiMLMJk5aIxVrlYgHJw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -6522,9 +6413,9 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
-      "integrity": "sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz",
+      "integrity": "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8-varint": "^2.0.2",
@@ -6533,9 +6424,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -6581,10 +6472,13 @@
       }
     },
     "node_modules/race-event": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.3.0.tgz",
-      "integrity": "sha512-kaLm7axfOnahIqD3jQ4l1e471FIFcEGebXEnhxyLscuUzV8C94xVHtWEqDDXxll7+yu/6lW0w1Ff4HbtvHvOHg==",
-      "license": "Apache-2.0 OR MIT"
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.6.1.tgz",
+      "integrity": "sha512-vi7WH5g5KoTFpu2mme/HqZiWH14XSOtg5rfp6raBskBHl7wnmy3F/biAIyY5MsK+BHWhoPhxtZ1Y2R7OHHaWyQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "abort-error": "^1.0.1"
+      }
     },
     "node_modules/race-signal": {
       "version": "1.1.3",
@@ -6650,9 +6544,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.1.tgz",
-      "integrity": "sha512-TFo1MEnkqE6hzAbaztnyR5uLTMoz6wnEWwWBsCUzNt+sVXJycuRJdDqvL078M4/h65BI/YO5XWTaxZDWVsW0fw==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+      "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6805,9 +6699,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6889,9 +6783,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7016,9 +6910,9 @@
       "peer": true
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7232,9 +7126,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -7260,14 +7154,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -7301,9 +7195,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7363,9 +7257,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7418,9 +7312,9 @@
       "license": "0BSD"
     },
     "node_modules/tsyringe": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.9.1.tgz",
-      "integrity": "sha512-dJCWk0RolAnGk0j839M0lcuS/PtNUPaMsnBosn+wg5N16xy0tofcVuvsidMs0JuRbaJ0wVIT7RsuHWbVIZ5Rcg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.3"
@@ -7622,22 +7516,22 @@
       }
     },
     "node_modules/weald": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/weald/-/weald-1.0.4.tgz",
-      "integrity": "sha512-+kYTuHonJBwmFhP1Z4YQK/dGi3jAnJGCYhyODFpHK73rbxnp9lnZQj7a2m+WVgn8fXr5bJaxUpF6l8qZpPeNWQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.0.6.tgz",
+      "integrity": "sha512-sX1PzkcMJZUJ848JbFzB6aKHHglTxqACEnq2KgI75b7vWYvfXFBNbOuDKqFKwCT44CrP6c5r+L4+5GmPnb5/SQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "ms": "^3.0.0-canary.1",
-        "supports-color": "^9.4.0"
+        "supports-color": "^10.0.0"
       }
     },
     "node_modules/weald/node_modules/supports-color": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
@@ -7725,9 +7619,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/node-js-peer/package.json
+++ b/node-js-peer/package.json
@@ -30,7 +30,7 @@
     "multiformats": "^13.3.2",
     "protons-runtime": "^5.5.0",
     "react": "^18.3.1",
-    "react-curse": "^1.0.0",
+    "react-curse": "1.0.15",
     "uint8arraylist": "^2.4.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Somewhere between 1.0.15 and 1.0.22 react-curse broke the UI. There's [no convenient overview](https://github.com/infely/react-curse/issues/100) of changes for that module so just pin it to the last working version while investigation is ongoing.