### PR TITLE
[go-peer]: roomName handling + used as service name for mDNS discovery

### DIFF
--- a/go-peer/chatroom.go
+++ b/go-peer/chatroom.go
@@ -52,7 +52,7 @@ type ChatMessage struct {
 
 // JoinChatRoom tries to subscribe to the PubSub topic for the room name, returning
 // a ChatRoom on success.
-func JoinChatRoom(ctx context.Context, h host.Host, ps *pubsub.PubSub, nickname string) (*ChatRoom, error) {
+func JoinChatRoom(ctx context.Context, h host.Host, ps *pubsub.PubSub, nickname string, roomName string) (*ChatRoom, error) {
 	// join the pubsub chatTopic
 	chatTopic, err := ps.Join(ChatTopic)
 	if err != nil {
@@ -100,6 +100,7 @@ func JoinChatRoom(ctx context.Context, h host.Host, ps *pubsub.PubSub, nickname 
 		peerDiscoveryTopic: peerDiscoveryTopic,
 		peerDiscoverySub:   peerDiscoverySub,
 		nick:               nickname,
+		roomName:           roomName,
 		Messages:           make(chan *ChatMessage, ChatRoomBufSize),
 		SysMessages:        make(chan *ChatMessage, ChatRoomBufSize),
 	}

--- a/go-peer/main.go
+++ b/go-peer/main.go
@@ -108,6 +108,7 @@ func main() {
 	// parse some flags to set our nickname and the room to join
 	nickFlag := flag.String("nick", "", "nickname to use in chat. will be generated if empty")
 	idPath := flag.String("identity", "identity.key", "path to the private key (PeerID) file")
+roomFlag := flag.String("room", "", "The room to join")
 	headless := flag.Bool("headless", false, "run without chat UI")
 
 	var addrsToConnectTo stringSlice
@@ -210,8 +211,13 @@ func main() {
 		nick = defaultNick(h.ID())
 	}
 
+	roomName := *roomFlag
+	if len(roomName) == 0 {
+		roomName = defaultRoom()
+	}
+
 	// join the chat room
-	cr, err := JoinChatRoom(ctx, h, ps, nick)
+	cr, err := JoinChatRoom(ctx, h, ps, nick, roomName)
 	if err != nil {
 		panic(err)
 	}
@@ -313,6 +319,10 @@ func printErr(m string, args ...interface{}) {
 // the last 8 chars of a peer ID.
 func defaultNick(p peer.ID) string {
 	return fmt.Sprintf("%s-%s", os.Getenv("USER"), shortID(p))
+}
+
+func defaultRoom() string {
+	return "default"
 }
 
 // shortID returns the last 8 chars of a base58-encoded peer id.

--- a/go-peer/ui.go
+++ b/go-peer/ui.go
@@ -34,7 +34,7 @@ func NewChatUI(cr *ChatRoom) *ChatUI {
 	msgBox := tview.NewTextView()
 	msgBox.SetDynamicColors(true)
 	msgBox.SetBorder(true)
-	msgBox.SetTitle(fmt.Sprintf("Room: %s", cr.roomName))
+	msgBox.SetTitle(fmt.Sprintf("Room: %s ", cr.roomName))
 
 	// text views are io.Writers, but they don't automatically refresh.
 	// this sets a change handler to force the app to redraw when we get


### PR DESCRIPTION
The room flag is mentioned in the docs but it's not handled. 

This PR reads the flag, display it on top TUI and is using as service name for mDNS discovery tag.

+ random port assignment for instead of hardcoded `9095`

Demo:

https://github.com/user-attachments/assets/77b4c32b-a9a2-4d91-9f70-86deabcda8e9

