### PR TITLE
ci(js-peer): deploy static site to GitHub Pages

### DIFF
--- a/.github/workflows/js-peer.yml
+++ b/.github/workflows/js-peer.yml
@@ -2,8 +2,8 @@ name: js-peer build
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
+  pages: write
+  id-token: write
 
 on:
   push:
@@ -13,26 +13,56 @@ on:
     paths:
       - 'js-peer/**' # only run for PRs changing js-peer
 
+concurrency:
+  group: js-peer-pages
+  cancel-in-progress: true
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: js-peer
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+        id: pages
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
       - run: npm ci
       - run: npm run lint
-      - run: npm run build
-      - uses: ipfs/ipfs-deploy-action@v1
-        name: Deploy to IPFS
-        id: deploy
+      - name: Build static js-peer site
+        env:
+          GITHUB_PAGES: 'true'
+          PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: npm run build
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
         with:
-          # 👇 note that working-directory doesn't apply to action steps with `uses`, so we need to specify the full path
-          path-to-deploy: js-peer/out
-          storacha-key: ${{ secrets.STORACHA_KEY }}
-          storacha-proof: ${{ secrets.STORACHA_PROOF }}
-          github-token: ${{ github.token }}
+          path: js-peer/out
+      - name: Summarize GitHub Pages build
+        run: |
+          {
+            echo '## GitHub Pages Build'
+            echo
+            echo "- Pages base path: \`${{ steps.pages.outputs.base_path }}\`"
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              echo '- Deployment target: GitHub Pages'
+            else
+              echo '- Pull requests build the static site but do not deploy it.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/js-peer/next.config.js
+++ b/js-peer/next.config.js
@@ -1,8 +1,19 @@
 /** @type {import('next').NextConfig} */
+const isGitHubPages = process.env.GITHUB_PAGES === 'true'
+const rawBasePath = process.env.PAGES_BASE_PATH || ''
+const basePath =
+  isGitHubPages && rawBasePath && rawBasePath !== '/'
+    ? rawBasePath.startsWith('/')
+      ? rawBasePath
+      : `/${rawBasePath}`
+    : ''
+
 const nextConfig = {
   output: 'export',
   reactStrictMode: true,
   productionBrowserSourceMaps: true,
+  basePath,
+  assetPrefix: basePath || undefined,
   images: {
     unoptimized: true,
   },

--- a/js-peer/src/components/booting.tsx
+++ b/js-peer/src/components/booting.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Image from 'next/image'
+import { useRouter } from 'next/router'
 import Spinner from './spinner'
 
 interface Props {
@@ -7,10 +7,13 @@ interface Props {
 }
 
 export function Booting({ error }: Props) {
+  const router = useRouter()
+  const logoSrc = `${router.basePath || ''}/libp2p-logo.svg`
+
   return (
     <div className="grid h-screen place-items-center">
       <div className="text-center">
-        <Image src="/libp2p-logo.svg" alt="libp2p logo" height="156" width="156" className="text-white mx-auto mb-5" />
+        <img src={logoSrc} alt="libp2p logo" height="156" width="156" className="text-white mx-auto mb-5" />
         <h2 className="text-3xl font-bold text-gray-900 mb-2">Initializing libp2p peer</h2>
         {!error && (
           <>

--- a/js-peer/src/components/nav.tsx
+++ b/js-peer/src/components/nav.tsx
@@ -2,7 +2,6 @@ import { Fragment } from 'react'
 import { Disclosure, DisclosureButton, DisclosurePanel, Menu, Transition } from '@headlessui/react'
 import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
-import Image from 'next/image'
 import { useRouter } from 'next/router'
 
 const navigationItems = [{ name: 'Source', href: 'https://github.com/libp2p/universal-connectivity' }]
@@ -13,6 +12,8 @@ function classNames(...classes: string[]) {
 
 export default function Navigation({ connectionInfoButton }: { connectionInfoButton?: React.ReactNode }) {
   const router = useRouter()
+  const logoSrc = `${router.basePath || ''}/libp2p-logo.svg`
+  const heroSrc = `${router.basePath || ''}/libp2p-hero.svg`
 
   return (
     <Disclosure as="nav" className="border-b border-gray-200 bg-white">
@@ -22,16 +23,10 @@ export default function Navigation({ connectionInfoButton }: { connectionInfoBut
             <div className="flex h-16 justify-between items-center">
               <div className="flex items-center">
                 <div className="flex flex-shrink-0 items-center">
-                  <Image src="/libp2p-logo.svg" alt="libp2p logo" height="46" width="46" />
+                  <img src={logoSrc} alt="libp2p logo" height="46" width="46" />
                   <div className="ml-3 flex items-center">
                     <h1 className="text-xl font-semibold text-gray-900 hidden sm:block">Universal Connectivity</h1>
-                    <Image
-                      src="/libp2p-hero.svg"
-                      alt="libp2p hero"
-                      height="24"
-                      width="24"
-                      className="ml-2 hidden sm:block"
-                    />
+                    <img src={heroSrc} alt="libp2p hero" height="24" width="24" className="ml-2 hidden sm:block" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

This switches the `js-peer` deployment path from the current static Storacha/IPFS workflow to GitHub Pages.

It also fixes the broken project-site asset paths so the static app works correctly when served from a repository subpath like:

- https://nomadkids.github.io/universal-connectivity/

Fixes #342

## What changed

- replace the `js-peer` publish workflow with the official GitHub Pages Actions flow
  - `actions/configure-pages`
  - `actions/upload-pages-artifact`
  - `actions/deploy-pages`
- keep PRs as build/lint validation only
- deploy `main` to GitHub Pages
- add GitHub Pages-aware `basePath` / `assetPrefix`
- fix static logo asset paths so they resolve correctly on a project page

## Why

The current `js-peer` app is a static Next.js export, so GitHub Pages is a straightforward deployment target and fixes  former Storacha/IPFS for this frontend which stopped providing services.

## Preview

Preview fork deployment:

- https://nomadkids.github.io/universal-connectivity/

## Important setup note

GitHub Pages must be enabled for the repository, and the publishing source must be set to **GitHub Actions**.

Without that, `actions/configure-pages@v5` fails with a `Get Pages site failed` / `404 Not Found` error.

### Enable in GitHub UI

Go to:

- `Settings`
- `Pages`
- `Source` -> `GitHub Actions`

### Enable with GitHub CLI

If Pages has not been created yet:

```bash
gh api -X POST repos/libp2p/universal-connectivity/pages \
  -f build_type=workflow
